### PR TITLE
feat(s3-merge): refactoring and merging the cudl-dist and cudl-data-r…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 /cudl-production/.terraform.lock.hcl
 /modules/cudl-data-enhancements/properties_files/
 /modules/cudl-data-enhancements/zipped_properties_files/
+/modules/cudl-data-processing/.terraform/
+/modules/cudl-data-processing/.terraform.lock.hcl

--- a/cudl-dev/locals.tf
+++ b/cudl-dev/locals.tf
@@ -12,6 +12,6 @@ locals {
   additional_lambda_variables = {
     AWS_DATA_SOURCE_BUCKET   = "${local.environment}-cudl-data-source"
     AWS_TRANSCRIPTION_BUCKET = "${local.environment}-cudl-transcriptions" # NOTE to be removed
-    AWS_DIST_BUCKET          = "${local.environment}-cudl-dist"
+    AWS_OUTPUT_BUCKET        = "${local.environment}-cudl-data-releases"
   }
 }

--- a/cudl-dev/main.tf
+++ b/cudl-dev/main.tf
@@ -3,7 +3,6 @@ module "cudl-data-processing" {
   chunks                          = var.chunks
   compressed-lambdas-directory    = var.compressed-lambdas-directory
   data-function-name              = var.data-function-name
-  db-lambda-information           = var.db-lambda-information
   destination-bucket-name         = var.destination-bucket-name
   dst-efs-prefix                  = var.dst-efs-prefix
   dst-prefix                      = var.dst-prefix
@@ -27,8 +26,8 @@ module "cudl-data-processing" {
   lambda-db-secret-key            = var.lambda-db-secret-key
   lambda-db-url                   = var.lambda-db-url
   aws-account-number              = var.aws-account-number
-  source-bucket-sns-notifications = var.source-bucket-sns-notifications
-  source-bucket-sqs-notifications = var.source-bucket-sqs-notifications
+  transform-lambda-bucket-sns-notifications = var.transform-lambda-bucket-sns-notifications
+  transform-lambda-bucket-sqs-notifications = var.transform-lambda-bucket-sqs-notifications
   environment                     = var.environment
   transcription-pagify-xslt       = var.transcription-pagify-xslt
   transcription-mstei-xslt        = var.transcription-mstei-xslt

--- a/cudl-dev/main.tf
+++ b/cudl-dev/main.tf
@@ -32,7 +32,7 @@ module "cudl-data-processing" {
   environment                     = var.environment
   transcription-pagify-xslt       = var.transcription-pagify-xslt
   transcription-mstei-xslt        = var.transcription-mstei-xslt
-  source-bucket-names             = [var.source-bucket-name, var.distribution-bucket-name]
+  source-bucket-name              = var.source-bucket-name
 }
 
 module "cudl-data-enhancements" {

--- a/cudl-dev/terraform.tfvars
+++ b/cudl-dev/terraform.tfvars
@@ -20,7 +20,7 @@ lambda-db-jdbc-driver                = "org.postgresql.Driver"
 lambda-db-url                        = "jdbc:postgresql://<HOST>:<PORT>/dev_cudl_viewer?autoReconnect=true"
 lambda-db-secret-key                 = "dev/cudl/cudl_viewer_db"
 
-source-bucket-sns-notifications = [
+transform-lambda-bucket-sns-notifications = [
   {
     "bucket_name"   = "cudl-data-source"
     "filter_prefix" = "items/data/tei/",
@@ -42,7 +42,7 @@ source-bucket-sns-notifications = [
   }
 ]
 
-source-bucket-sqs-notifications = [
+transform-lambda-bucket-sqs-notifications = [
   {
     "type"          = "SQS",
     "queue_name"    = "CUDLPackageDataQueue_HTML",
@@ -208,9 +208,7 @@ enhancements-lambda-information = [{
   "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.XSLTTransformRequestHandler::handleRequest"
   "runtime"       = "java11"
 }]
-db-lambda-information = [
 
-]
 dst-efs-prefix              = "/mnt/cudl-data-releases"
 dst-prefix                  = "html/"
 dst-s3-prefix               = ""

--- a/cudl-dev/terraform.tfvars
+++ b/cudl-dev/terraform.tfvars
@@ -9,7 +9,6 @@ transcriptions-bucket-name           = "cudl-transcriptions"
 transkribus-bucket-name              = "cudl-data-enhancements"
 enhancements-destination-bucket-name = "cudl-data-source"
 source-bucket-name                   = "cudl-data-source"
-distribution-bucket-name             = "cudl-dist"
 compressed-lambdas-directory         = "compressed_lambdas"
 lambda-jar-bucket                    = "mvn.cudl.lib.cam.ac.uk"
 lambda-layer-name                    = "cudl-xslt-layer"
@@ -21,8 +20,6 @@ lambda-db-jdbc-driver                = "org.postgresql.Driver"
 lambda-db-url                        = "jdbc:postgresql://<HOST>:<PORT>/dev_cudl_viewer?autoReconnect=true"
 lambda-db-secret-key                 = "dev/cudl/cudl_viewer_db"
 
-// NOTE: If you are adding anything here you need to add a code block to
-// the s3.tf file
 source-bucket-sns-notifications = [
   {
     "bucket_name"   = "cudl-data-source"
@@ -44,8 +41,7 @@ source-bucket-sns-notifications = [
     ]
   }
 ]
-// NOTE: If you are adding anything here you need to add a code block to
-// the s3.tf file
+
 source-bucket-sqs-notifications = [
   {
     "type"          = "SQS",
@@ -87,6 +83,27 @@ source-bucket-sqs-notifications = [
     "filter_prefix" = "ui/"
     "filter_suffix" = ""
     "bucket_name"   = "cudl-data-source"
+  },
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataDatasetQueue"
+    "filter_prefix" = "cudl.dl-dataset.json"
+    "filter_suffix" = ""
+    "bucket_name"   = "cudl-data-releases"
+  },
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataUIQueue"
+    "filter_prefix" = "cudl.ui.json"
+    "filter_suffix" = ""
+    "bucket_name"   = "cudl-data-releases"
+  },
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataUpdateDBQueue"
+    "filter_prefix" = "collections/"
+    "filter_suffix" = ".json"
+    "bucket_name"   = "cudl-data-releases"
   }
 ]
 transform-lambda-information = [
@@ -145,6 +162,39 @@ transform-lambda-information = [
     "memory"        = 1024
     "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.GenerateTranscriptionHTMLHandler::handleRequest"
     "runtime"       = "java11"
+  },
+  {
+    "name"          = "AWSLambda_CUDLPackageData_UPDATE_DB"
+    "description"   = "Updates the CUDL database with collection information from the collections json file"
+    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
+    "queue_name"    = "CUDLPackageDataUpdateDBQueue"
+    "transcription" = false
+    "timeout"       = 900
+    "memory"        = 512
+    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.CollectionFileDBHandler::handleRequest"
+    "runtime"       = "java11"
+  },
+  {
+    "name"          = "AWSLambda_CUDLPackageData_DATASET_JSON"
+    "description"   = "Transforms the dataset json file into a json format with suitable paths for the viewer / db"
+    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
+    "queue_name"    = "CUDLPackageDataDatasetQueue"
+    "transcription" = false
+    "timeout"       = 900
+    "memory"        = 512
+    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.DatasetFileDBHandler::handleRequest"
+    "runtime"       = "java11"
+  },
+  {
+    "name"          = "AWSLambda_CUDLPackageData_UI_JSON"
+    "description"   = "Transforms the UI json file into a json format with suitable paths for the viewer / db"
+    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
+    "queue_name"    = "CUDLPackageDataUIQueue"
+    "transcription" = false
+    "timeout"       = 900
+    "memory"        = 512
+    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.UIFileDBHandler::handleRequest"
+    "runtime"       = "java11"
   }
 ]
 enhancements-lambda-information = [{
@@ -159,40 +209,7 @@ enhancements-lambda-information = [{
   "runtime"       = "java11"
 }]
 db-lambda-information = [
-  {
-    "name"          = "AWSLambda_CUDLPackageData_UPDATE_DB"
-    "description"   = "Updates the CUDL database with collection information from the collections json file"
-    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
-    "queue_name"    = "CUDLPackageDataUpdateDBQueue"
-    "timeout"       = 900
-    "memory"        = 512
-    "filter_prefix" = "collections/"
-    "filter_suffix" = ".json"
-    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.CollectionFileDBHandler::handleRequest"
-    "runtime"       = "java11"
-  },
-  {
-    "name"          = "AWSLambda_CUDLPackageData_DATASET_JSON"
-    "description"   = "Transforms the dataset json file into a json format with suitable paths for the viewer / db"
-    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
-    "queue_name"    = "CUDLPackageDataDatasetQueue"
-    "timeout"       = 900
-    "memory"        = 512
-    "filter_prefix" = "cudl.dl-dataset.json"
-    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.DatasetFileDBHandler::handleRequest"
-    "runtime"       = "java11"
-  },
-  {
-    "name"          = "AWSLambda_CUDLPackageData_UI_JSON"
-    "description"   = "Transforms the UI json file into a json format with suitable paths for the viewer / db"
-    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
-    "queue_name"    = "CUDLPackageDataUIQueue"
-    "timeout"       = 900
-    "memory"        = 512
-    "filter_prefix" = "cudl.ui.json"
-    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.UIFileDBHandler::handleRequest"
-    "runtime"       = "java11"
-  }
+
 ]
 dst-efs-prefix              = "/mnt/cudl-data-releases"
 dst-prefix                  = "html/"

--- a/cudl-dev/tests/dev.tftest.hcl
+++ b/cudl-dev/tests/dev.tftest.hcl
@@ -28,38 +28,38 @@ run "transform_lambda_sqs_queue_length" {
   }
 }
 
-run "source_item_updated_sns_topic_length" {
+run "transform_sns_topic_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_item_updated_sns_topic_length == length(var.source-bucket-sns-notifications)
+    condition     = module.cudl-data-processing.transform_sns_topic_length == length(var.transform-lambda-bucket-sns-notifications)
     error_message = "Number of SNS topics does not match expected value"
   }
 }
 
-run "item_update_topic_subscriptions_length" {
+run "transform_sns_topic_subscriptions_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.item_update_topic_subscriptions_length == length(flatten(var.source-bucket-sns-notifications[*].subscriptions))
+    condition     = module.cudl-data-processing.transform_sns_topic_subscriptions_length == length(flatten(var.transform-lambda-bucket-sns-notifications[*].subscriptions))
     error_message = "Number of SNS topics subscriptions does not match expected value"
   }
 }
 
-run "source_bucket_notification_topics_length" {
+run "transform_bucket_notification_topics_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_bucket_notification_topics_length == length(var.source-bucket-sns-notifications)
+    condition     = module.cudl-data-processing.transform_bucket_notification_topics_length == length(var.transform-lambda-bucket-sns-notifications)
     error_message = "Number of S3 Bucket SNS topic subscriptions does not match expected value"
   }
 }
 
-run "source_bucket_notification_queues_length" {
+run "transform_bucket_notification_queues_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_bucket_notification_queues_length == length(var.source-bucket-sqs-notifications)
+    condition     = module.cudl-data-processing.transform_bucket_notification_queues_length == length(var.transform-lambda-bucket-sqs-notifications)
     error_message = "Number of S3 Bucket SQS Queue subscriptions does not match expected value"
   }
 }

--- a/cudl-dev/variables.tf
+++ b/cudl-dev/variables.tf
@@ -233,7 +233,3 @@ variable "source-bucket-sqs-notifications" {
   description = "List of SQS notifications on source s3 bucket"
   type        = list(any)
 }
-
-variable "distribution-bucket-name" {
-  description = "The name of the s3 bucket that stores the output of the data processing pipeline. Will be prefixed with the environment value."
-}

--- a/cudl-dev/variables.tf
+++ b/cudl-dev/variables.tf
@@ -134,11 +134,6 @@ variable "enhancements-lambda-information" {
   type        = list(any)
 }
 
-variable "db-lambda-information" {
-  description = "A list of maps containing information about the database lambda functions"
-  type        = list(any)
-}
-
 variable "dst-efs-prefix" {
   description = "Use to set the DST_EFS_PREFIX variable in the properties file passed to the lambda layer"
   type        = string
@@ -224,12 +219,12 @@ variable "efs-name" {
   type        = string
 }
 
-variable "source-bucket-sns-notifications" {
-  description = "List of SNS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sns-notifications" {
+  description = "List of SNS notifications on an s3 bucket"
   type        = list(any)
 }
 
-variable "source-bucket-sqs-notifications" {
-  description = "List of SQS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sqs-notifications" {
+  description = "List of SQS notifications on an s3 bucket"
   type        = list(any)
 }

--- a/cudl-production/locals.tf
+++ b/cudl-production/locals.tf
@@ -12,6 +12,6 @@ locals {
   additional_lambda_variables = {
     AWS_DATA_SOURCE_BUCKET   = "${local.environment}-cudl-data-source"
     AWS_TRANSCRIPTION_BUCKET = "${local.environment}-cudl-transcriptions" # NOTE to be removed
-    AWS_DIST_BUCKET          = "${local.environment}-cudl-dist"
+    AWS_OUTPUT_BUCKET        = "${local.environment}-cudl-data-releases"
   }
 }

--- a/cudl-production/main.tf
+++ b/cudl-production/main.tf
@@ -32,5 +32,5 @@ module "cudl-data-processing" {
   environment                     = var.environment
   transcription-pagify-xslt       = var.transcription-pagify-xslt
   transcription-mstei-xslt        = var.transcription-mstei-xslt
-  source-bucket-names             = [var.source-bucket-name, var.distribution-bucket-name]
+  source-bucket-name              = var.source-bucket-name
 }

--- a/cudl-production/main.tf
+++ b/cudl-production/main.tf
@@ -3,7 +3,6 @@ module "cudl-data-processing" {
   chunks                          = var.chunks
   compressed-lambdas-directory    = var.compressed-lambdas-directory
   data-function-name              = var.data-function-name
-  db-lambda-information           = var.db-lambda-information
   destination-bucket-name         = var.destination-bucket-name
   dst-efs-prefix                  = var.dst-efs-prefix
   dst-prefix                      = var.dst-prefix
@@ -27,8 +26,8 @@ module "cudl-data-processing" {
   lambda-db-secret-key            = var.lambda-db-secret-key
   lambda-db-url                   = var.lambda-db-url
   aws-account-number              = var.aws-account-number
-  source-bucket-sns-notifications = var.source-bucket-sns-notifications
-  source-bucket-sqs-notifications = var.source-bucket-sqs-notifications
+  transform-lambda-bucket-sns-notifications = var.transform-lambda-bucket-sns-notifications
+  transform-lambda-bucket-sqs-notifications = var.transform-lambda-bucket-sqs-notifications
   environment                     = var.environment
   transcription-pagify-xslt       = var.transcription-pagify-xslt
   transcription-mstei-xslt        = var.transcription-mstei-xslt

--- a/cudl-production/terraform.tfvars
+++ b/cudl-production/terraform.tfvars
@@ -15,9 +15,9 @@ lambda-db-jdbc-driver        = "org.postgresql.Driver"
 lambda-db-url                = "jdbc:postgresql://<HOST>:<PORT>/production_cudl_viewer?autoReconnect=true"
 lambda-db-secret-key         = "production/cudl/cudl_viewer_db"
 
-source-bucket-sns-notifications = [
+transform-lambda-bucket-sns-notifications = [
 ]
-source-bucket-sqs-notifications = [
+transform-lambda-bucket-sqs-notifications = [
   {
     "type"          = "SQS",
     "queue_name"    = "CUDLPackageDataDatasetQueue"
@@ -74,9 +74,6 @@ transform-lambda-information = [
     "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.UIFileDBHandler::handleRequest"
     "runtime"       = "java11"
   }
-]
-db-lambda-information = [
-
 ]
 dst-efs-prefix              = "/mnt/cudl-data-releases"
 dst-prefix                  = "html/"

--- a/cudl-production/terraform.tfvars
+++ b/cudl-production/terraform.tfvars
@@ -6,7 +6,6 @@ aws-account-number           = "247242244017"
 destination-bucket-name      = "cudl-data-releases"
 transcriptions-bucket-name   = "cudl-transcriptions"
 source-bucket-name           = "cudl-data-source"
-distribution-bucket-name     = "cudl-dist"
 compressed-lambdas-directory = "compressed_lambdas"
 lambda-jar-bucket            = "mvn.cudl.lib.cam.ac.uk"
 lambda-layer-name            = "cudl-xslt-layer"
@@ -19,19 +18,37 @@ lambda-db-secret-key         = "production/cudl/cudl_viewer_db"
 source-bucket-sns-notifications = [
 ]
 source-bucket-sqs-notifications = [
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataDatasetQueue"
+    "filter_prefix" = "cudl.dl-dataset.json"
+    "filter_suffix" = ""
+    "bucket_name"   = "cudl-data-releases"
+  },
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataUIQueue"
+    "filter_prefix" = "cudl.ui.json"
+    "filter_suffix" = ""
+    "bucket_name"   = "cudl-data-releases"
+  },
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataUpdateDBQueue"
+    "filter_prefix" = "collections/"
+    "filter_suffix" = ".json"
+    "bucket_name"   = "cudl-data-releases"
+  }
 ]
 transform-lambda-information = [
-]
-db-lambda-information = [
   {
     "name"          = "AWSLambda_CUDLPackageData_UPDATE_DB"
     "description"   = "Updates the CUDL database with collection information from the collections json file"
     "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.15/AWSLambda_Data_Transform-0.15-jar-with-dependencies.jar"
     "queue_name"    = "CUDLPackageDataUpdateDBQueue"
+    "transcription" = false
     "timeout"       = 900
     "memory"        = 512
-    "filter_prefix" = "collections/"
-    "filter_suffix" = ".json"
     "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.CollectionFileDBHandler::handleRequest"
     "runtime"       = "java11"
   },
@@ -40,9 +57,9 @@ db-lambda-information = [
     "description"   = "Transforms the dataset json file into a json format with suitable paths for the viewer / db"
     "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.15/AWSLambda_Data_Transform-0.15-jar-with-dependencies.jar"
     "queue_name"    = "CUDLPackageDataDatasetQueue"
+    "transcription" = false
     "timeout"       = 900
     "memory"        = 512
-    "filter_prefix" = "cudl.dl-dataset.json"
     "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.DatasetFileDBHandler::handleRequest"
     "runtime"       = "java11"
   },
@@ -51,12 +68,15 @@ db-lambda-information = [
     "description"   = "Transforms the UI json file into a json format with suitable paths for the viewer / db"
     "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.15/AWSLambda_Data_Transform-0.15-jar-with-dependencies.jar"
     "queue_name"    = "CUDLPackageDataUIQueue"
+    "transcription" = false
     "timeout"       = 900
     "memory"        = 512
-    "filter_prefix" = "cudl.ui.json"
     "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.UIFileDBHandler::handleRequest"
     "runtime"       = "java11"
   }
+]
+db-lambda-information = [
+
 ]
 dst-efs-prefix              = "/mnt/cudl-data-releases"
 dst-prefix                  = "html/"

--- a/cudl-production/tests/production.tftest.hcl
+++ b/cudl-production/tests/production.tftest.hcl
@@ -28,38 +28,38 @@ run "transform_lambda_sqs_queue_length" {
   }
 }
 
-run "source_item_updated_sns_topic_length" {
+run "transform_sns_topic_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_item_updated_sns_topic_length == length(var.source-bucket-sns-notifications)
+    condition     = module.cudl-data-processing.transform_sns_topic_length == length(var.transform-lambda-bucket-sns-notifications)
     error_message = "Number of SNS topics does not match expected value"
   }
 }
 
-run "item_update_topic_subscriptions_length" {
+run "transform_sns_topic_subscriptions_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.item_update_topic_subscriptions_length == length(flatten(var.source-bucket-sns-notifications[*].subscriptions))
+    condition     = module.cudl-data-processing.transform_sns_topic_subscriptions_length == length(flatten(var.transform-lambda-bucket-sns-notifications[*].subscriptions))
     error_message = "Number of SNS topics subscriptions does not match expected value"
   }
 }
 
-run "source_bucket_notification_topics_length" {
+run "transform_bucket_notification_topics_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_bucket_notification_topics_length == length(var.source-bucket-sns-notifications)
+    condition     = module.cudl-data-processing.transform_bucket_notification_topics_length == length(var.transform-lambda-bucket-sns-notifications)
     error_message = "Number of S3 Bucket SNS topic subscriptions does not match expected value"
   }
 }
 
-run "source_bucket_notification_queues_length" {
+run "transform_bucket_notification_queues_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_bucket_notification_queues_length == length(var.source-bucket-sqs-notifications)
+    condition     = module.cudl-data-processing.transform_bucket_notification_queues_length == length(var.transform-lambda-bucket-sns-notifications)
     error_message = "Number of S3 Bucket SQS Queue subscriptions does not match expected value"
   }
 }

--- a/cudl-production/variables.tf
+++ b/cudl-production/variables.tf
@@ -182,7 +182,3 @@ variable "source-bucket-sqs-notifications" {
   description = "List of SQS notifications on source s3 bucket"
   type        = list(any)
 }
-
-variable "distribution-bucket-name" {
-  description = "The name of the s3 bucket that stores the output of the data processing pipeline. Will be prefixed with the environment value."
-}

--- a/cudl-production/variables.tf
+++ b/cudl-production/variables.tf
@@ -98,11 +98,6 @@ variable "transcription-mstei-xslt" {
   type        = string
 }
 
-variable "db-lambda-information" {
-  description = "A list of maps containing information about the database lambda functions"
-  type        = list(any)
-}
-
 variable "dst-efs-prefix" {
   description = "Use to set the DST_EFS_PREFIX variable in the properties file passed to the lambda layer"
   type        = string
@@ -173,12 +168,12 @@ variable "efs-name" {
   type        = string
 }
 
-variable "source-bucket-sns-notifications" {
-  description = "List of SNS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sns-notifications" {
+  description = "List of SNS notifications on an s3 bucket"
   type        = list(any)
 }
 
-variable "source-bucket-sqs-notifications" {
-  description = "List of SQS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sqs-notifications" {
+  description = "List of SQS notifications on an s3 bucket"
   type        = list(any)
 }

--- a/cudl-sandbox/locals.tf
+++ b/cudl-sandbox/locals.tf
@@ -13,6 +13,6 @@ locals {
   additional_lambda_variables = {
     AWS_DATA_SOURCE_BUCKET   = "${local.environment}-cudl-data-source"
     AWS_TRANSCRIPTION_BUCKET = "${local.environment}-cudl-transcriptions" # NOTE to be removed
-    AWS_DIST_BUCKET          = "${local.environment}-cudl-dist"
+    AWS_OUTPUT_BUCKET        = "${local.environment}-cudl-data-releases"
   }
 }

--- a/cudl-sandbox/main.tf
+++ b/cudl-sandbox/main.tf
@@ -35,7 +35,7 @@ module "cudl-data-processing" {
   environment                             = local.environment
   transcription-pagify-xslt               = var.transcription-pagify-xslt
   transcription-mstei-xslt                = var.transcription-mstei-xslt
-  source-bucket-names                     = [var.source-bucket-name, var.distribution-bucket-name]
+  source-bucket-name                      = var.source-bucket-name
 }
 
 module "cudl-data-enhancements" {

--- a/cudl-sandbox/main.tf
+++ b/cudl-sandbox/main.tf
@@ -5,7 +5,6 @@ module "cudl-data-processing" {
   chunks                                  = var.chunks
   compressed-lambdas-directory            = var.compressed-lambdas-directory
   data-function-name                      = var.data-function-name
-  db-lambda-information                   = var.db-lambda-information
   destination-bucket-name                 = var.destination-bucket-name
   dst-efs-prefix                          = var.dst-efs-prefix
   dst-prefix                              = var.dst-prefix
@@ -30,8 +29,8 @@ module "cudl-data-processing" {
   lambda-db-secret-key                    = var.lambda-db-secret-key
   lambda-db-url                           = var.lambda-db-url
   aws-account-number                      = data.aws_caller_identity.current.account_id
-  source-bucket-sns-notifications         = var.source-bucket-sns-notifications
-  source-bucket-sqs-notifications         = var.source-bucket-sqs-notifications
+  transform-lambda-bucket-sns-notifications         = var.transform-lambda-bucket-sns-notifications
+  transform-lambda-bucket-sqs-notifications         = var.transform-lambda-bucket-sqs-notifications
   environment                             = local.environment
   transcription-pagify-xslt               = var.transcription-pagify-xslt
   transcription-mstei-xslt                = var.transcription-mstei-xslt

--- a/cudl-sandbox/terraform.tfvars
+++ b/cudl-sandbox/terraform.tfvars
@@ -8,7 +8,6 @@ transcriptions-bucket-name           = "cudl-transcriptions"
 transkribus-bucket-name              = "cudl-data-enhancements"
 enhancements-destination-bucket-name = "cudl-data-source"
 source-bucket-name                   = "cudl-data-source"
-distribution-bucket-name             = "cudl-dist"
 compressed-lambdas-directory         = "compressed_lambdas"
 lambda-jar-bucket                    = "sandbox.mvn.cudl.lib.cam.ac.uk"
 lambda-layer-name                    = "cudl-xslt-layer"
@@ -20,8 +19,6 @@ lambda-db-jdbc-driver                = "org.postgresql.Driver"
 lambda-db-url                        = "jdbc:postgresql://<HOST>:<PORT>/sandboxtf_cudl_viewer?autoReconnect=true"
 lambda-db-secret-key                 = "sandboxtf/cudl/cudl_viewer_db"
 
-// NOTE: If you are adding anything here you need to add a code block to
-// the s3.tf file
 source-bucket-sns-notifications = [
   {
     "bucket_name"   = "cudl-data-source"
@@ -37,10 +34,23 @@ source-bucket-sns-notifications = [
         "raw"        = true
       },
     ]
+  },
+  {
+    "bucket_name"   = "cudl-data-releases"
+    "filter_prefix" = "collections/",
+    "filter_suffix" = ".json"
+    "subscriptions" = [
+      {
+        "queue_name" = "CUDLIndexCollectionQueue",
+        "raw"        = true
+      },
+      {
+        "queue_name" = "CUDLPackageDataUpdateDBQueue",
+        "raw"        = true
+      },
+    ]
   }
 ]
-// NOTE: If you are adding anything here you need to add a code block to
-// the s3.tf file
 source-bucket-sqs-notifications = [
   {
     "type"          = "SQS",
@@ -87,7 +97,35 @@ source-bucket-sqs-notifications = [
     "queue_name"    = "CUDLIndexQueue"
     "filter_prefix" = "solr-json/"
     "filter_suffix" = ".json"
-    "bucket_name"   = "cudl-dist"
+    "bucket_name"   = "cudl-data-releases"
+  },
+#   {
+#     "type"          = "SQS",
+#     "queue_name"    = "CUDLIndexCollectionQueue"
+#     "filter_prefix" = "collection/"
+#     "filter_suffix" = ".json"
+#     "bucket_name"   = "cudl-data-releases"
+#   },
+#   {
+#     "type"          = "SQS",
+#     "queue_name"    = "CUDLPackageDataUpdateDBQueue"
+#     "filter_prefix" = "collections/"
+#     "filter_suffix" = ".json"
+#     "bucket_name"   = "cudl-data-releases"
+#   },
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataDatasetQueue"
+    "filter_prefix" = "cudl.dl-dataset.json"
+    "filter_suffix" = ""
+    "bucket_name"   = "cudl-data-releases"
+  },
+  {
+    "type"          = "SQS",
+    "queue_name"    = "CUDLPackageDataUIQueue"
+    "filter_prefix" = "cudl.ui.json"
+    "filter_suffix" = ""
+    "bucket_name"   = "cudl-data-releases"
   }
 ]
 transform-lambda-information = [
@@ -127,7 +165,7 @@ transform-lambda-information = [
   },
   {
     "name"                     = "AWSLambda_CUDLPackageData_TEI_Processing"
-    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-tei-processing@sha256:9a7fdab4f5ee6ab637669cbdf46c4a5f59783b87566fcc884cd65686c605387d"
+    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-tei-processing@sha256:5c2fdf33a259ee2bc3c21de7e19eccef41aa5126781ddd56eef0d66d2d58bc84"
     "queue_name"               = "CUDL_TEIProcessingQueue"
     "transcription"            = true
     "timeout"                  = 300
@@ -140,14 +178,17 @@ transform-lambda-information = [
     "mount_fs"                 = false
     "environment_variables" = {
       ANT_TARGET            = "full"
-      COLLECTION_XML_SOURCE = "/tmp/opt/cdcp/dist-pending/collection-xml"
-      CORE_XML_SOURCE       = "/tmp/opt/cdcp/dist-pending/core-xml"
-      PAGE_XML_SOURCE       = "/tmp/opt/cdcp/dist-pending/page-xml"
+      #COLLECTION_XML_SOURCE = "/tmp/opt/cdcp/dist-pending/collection-xml"
+      #CORE_XML_SOURCE       = "/tmp/opt/cdcp/dist-pending/core-xml"
+      #PAGE_XML_SOURCE       = "/tmp/opt/cdcp/dist-pending/page-xml"
+      SEARCH_HOST           = "3228e23cefe14d1291b146570655133a.solr-api-ccc.sandbox-solr"
+      SEARCH_PORT           = 8081
+      SEARCH_COLLECTION_PATH = "collection"
     }
   },
   {
     "name"                     = "AWSLambda_CUDLPackageData_SOLR_Listener"
-    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-solr-listener@sha256:404cb9574cc1a1f72969fc4f399d3176dc3d2217af62c59d3494eab24dfa13a6"
+    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-solr-listener@sha256:04e64aaeed3ac04a06952010dfae0d22397a567f3d39d03796d4124c8c0b439b"
     "queue_name"               = "CUDLIndexQueue"
     "transcription"            = false
     "vpc_name"                 = "sandbox-ccc-vpc"
@@ -164,7 +205,63 @@ transform-lambda-information = [
     "environment_variables" = {
       API_HOST = "3228e23cefe14d1291b146570655133a.solr-api-ccc.sandbox-solr"
       API_PORT = "8081"
+      API_PATH = "item"
     }
+  },
+  {
+    "name"                     = "AWSLambda_CUDLPackageData_Collection_SOLR_Listener"
+    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-solr-listener@sha256:04e64aaeed3ac04a06952010dfae0d22397a567f3d39d03796d4124c8c0b439b"
+    "queue_name"               = "CUDLIndexCollectionQueue"
+    "transcription"            = false
+    "vpc_name"                 = "sandbox-ccc-vpc"
+    "subnet_names"             = ["sandbox-ccc-subnet-private-a", "sandbox-ccc-subnet-private-b"]
+    "security_group_names"     = ["sandbox-ccc-vpc-endpoints", "sandbox-solr-private-access"]
+    "timeout"                  = 180
+    "memory"                   = 1024
+    "batch_window"             = 2
+    "batch_size"               = 1
+    "maximum_concurrency"      = 100
+    "use_datadog_variables"    = false
+    "use_additional_variables" = true
+    "mount_fs"                 = false
+    "environment_variables" = {
+      API_HOST = "3228e23cefe14d1291b146570655133a.solr-api-ccc.sandbox-solr"
+      API_PORT = "8081"
+      API_PATH = "collection"
+    }
+  },
+  {
+    "name"          = "AWSLambda_CUDLPackageData_UPDATE_DB"
+    "description"   = "Updates the CUDL database with collection information from the collections json file"
+    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
+    "queue_name"    = "CUDLPackageDataUpdateDBQueue"
+    "transcription"            = false
+    "timeout"       = 900
+    "memory"        = 512
+    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.CollectionFileDBHandler::handleRequest"
+    "runtime"       = "java11"
+  },
+  {
+    "name"          = "AWSLambda_CUDLPackageData_DATASET_JSON"
+    "description"   = "Transforms the dataset json file into a json format with suitable paths for the viewer / db"
+    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
+    "queue_name"    = "CUDLPackageDataDatasetQueue"
+    "transcription"            = false
+    "timeout"       = 900
+    "memory"        = 512
+    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.DatasetFileDBHandler::handleRequest"
+    "runtime"       = "java11"
+  },
+  {
+    "name"          = "AWSLambda_CUDLPackageData_UI_JSON"
+    "description"   = "Transforms the UI json file into a json format with suitable paths for the viewer / db"
+    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
+    "queue_name"    = "CUDLPackageDataUIQueue"
+    "transcription"            = false
+    "timeout"       = 900
+    "memory"        = 512
+    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.UIFileDBHandler::handleRequest"
+    "runtime"       = "java11"
   }
 ]
 enhancements-lambda-information = [{
@@ -179,40 +276,7 @@ enhancements-lambda-information = [{
   "runtime"       = "java11"
 }]
 db-lambda-information = [
-  {
-    "name"          = "AWSLambda_CUDLPackageData_UPDATE_DB"
-    "description"   = "Updates the CUDL database with collection information from the collections json file"
-    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
-    "queue_name"    = "CUDLPackageDataUpdateDBQueue"
-    "timeout"       = 900
-    "memory"        = 512
-    "filter_prefix" = "collections/"
-    "filter_suffix" = ".json"
-    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.CollectionFileDBHandler::handleRequest"
-    "runtime"       = "java11"
-  },
-  {
-    "name"          = "AWSLambda_CUDLPackageData_DATASET_JSON"
-    "description"   = "Transforms the dataset json file into a json format with suitable paths for the viewer / db"
-    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
-    "queue_name"    = "CUDLPackageDataDatasetQueue"
-    "timeout"       = 900
-    "memory"        = 512
-    "filter_prefix" = "cudl.dl-dataset.json"
-    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.DatasetFileDBHandler::handleRequest"
-    "runtime"       = "java11"
-  },
-  {
-    "name"          = "AWSLambda_CUDLPackageData_UI_JSON"
-    "description"   = "Transforms the UI json file into a json format with suitable paths for the viewer / db"
-    "jar_path"      = "release/uk/ac/cam/lib/cudl/awslambda/AWSLambda_Data_Transform/0.16/AWSLambda_Data_Transform-0.16-jar-with-dependencies.jar"
-    "queue_name"    = "CUDLPackageDataUIQueue"
-    "timeout"       = 900
-    "memory"        = 512
-    "filter_prefix" = "cudl.ui.json"
-    "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.UIFileDBHandler::handleRequest"
-    "runtime"       = "java11"
-  }
+
 ]
 dst-efs-prefix              = "/mnt/cudl-data-releases"
 dst-prefix                  = "html/"
@@ -229,7 +293,7 @@ lambda-alias-name           = "LIVE"
 
 # Existing vpc info
 vpc-id            = "vpc-057886e0bdd7c4e43"
-subnet-id         = "subnet-0f2b1a30b3838d5f1"
+subnet-id         = "subnet-02c0767268df8f171"
 security-group-id = "sg-032f9f202ea602d21"
 
 releases-root-directory-path = "/data"

--- a/cudl-sandbox/terraform.tfvars
+++ b/cudl-sandbox/terraform.tfvars
@@ -19,7 +19,7 @@ lambda-db-jdbc-driver                = "org.postgresql.Driver"
 lambda-db-url                        = "jdbc:postgresql://<HOST>:<PORT>/sandboxtf_cudl_viewer?autoReconnect=true"
 lambda-db-secret-key                 = "sandboxtf/cudl/cudl_viewer_db"
 
-source-bucket-sns-notifications = [
+transform-lambda-bucket-sns-notifications = [
   {
     "bucket_name"   = "cudl-data-source"
     "filter_prefix" = "items/data/tei/",
@@ -51,7 +51,7 @@ source-bucket-sns-notifications = [
     ]
   }
 ]
-source-bucket-sqs-notifications = [
+transform-lambda-bucket-sqs-notifications = [
   {
     "type"          = "SQS",
     "queue_name"    = "CUDLPackageDataQueue_HTML",
@@ -99,20 +99,6 @@ source-bucket-sqs-notifications = [
     "filter_suffix" = ".json"
     "bucket_name"   = "cudl-data-releases"
   },
-#   {
-#     "type"          = "SQS",
-#     "queue_name"    = "CUDLIndexCollectionQueue"
-#     "filter_prefix" = "collection/"
-#     "filter_suffix" = ".json"
-#     "bucket_name"   = "cudl-data-releases"
-#   },
-#   {
-#     "type"          = "SQS",
-#     "queue_name"    = "CUDLPackageDataUpdateDBQueue"
-#     "filter_prefix" = "collections/"
-#     "filter_suffix" = ".json"
-#     "bucket_name"   = "cudl-data-releases"
-#   },
   {
     "type"          = "SQS",
     "queue_name"    = "CUDLPackageDataDatasetQueue"
@@ -178,9 +164,6 @@ transform-lambda-information = [
     "mount_fs"                 = false
     "environment_variables" = {
       ANT_TARGET            = "full"
-      #COLLECTION_XML_SOURCE = "/tmp/opt/cdcp/dist-pending/collection-xml"
-      #CORE_XML_SOURCE       = "/tmp/opt/cdcp/dist-pending/core-xml"
-      #PAGE_XML_SOURCE       = "/tmp/opt/cdcp/dist-pending/page-xml"
       SEARCH_HOST           = "3228e23cefe14d1291b146570655133a.solr-api-ccc.sandbox-solr"
       SEARCH_PORT           = 8081
       SEARCH_COLLECTION_PATH = "collection"
@@ -275,9 +258,6 @@ enhancements-lambda-information = [{
   "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.XSLTTransformRequestHandler::handleRequest"
   "runtime"       = "java11"
 }]
-db-lambda-information = [
-
-]
 dst-efs-prefix              = "/mnt/cudl-data-releases"
 dst-prefix                  = "html/"
 dst-s3-prefix               = ""

--- a/cudl-sandbox/variables.tf
+++ b/cudl-sandbox/variables.tf
@@ -138,11 +138,6 @@ variable "enhancements-lambda-information" {
   type        = list(any)
 }
 
-variable "db-lambda-information" {
-  description = "A list of maps containing information about the database lambda functions"
-  type        = list(any)
-}
-
 variable "dst-efs-prefix" {
   description = "Use to set the DST_EFS_PREFIX variable in the properties file passed to the lambda layer"
   type        = string
@@ -228,12 +223,12 @@ variable "efs-name" {
   type        = string
 }
 
-variable "source-bucket-sns-notifications" {
-  description = "List of SNS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sns-notifications" {
+  description = "List of SNS notifications on an s3 bucket"
   type        = list(any)
 }
 
-variable "source-bucket-sqs-notifications" {
-  description = "List of SQS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sqs-notifications" {
+  description = "List of SQS notifications on an s3 bucket"
   type        = list(any)
 }

--- a/cudl-sandbox/variables.tf
+++ b/cudl-sandbox/variables.tf
@@ -237,7 +237,3 @@ variable "source-bucket-sqs-notifications" {
   description = "List of SQS notifications on source s3 bucket"
   type        = list(any)
 }
-
-variable "distribution-bucket-name" {
-  description = "The name of the s3 bucket that stores the output of the data processing pipeline. Will be prefixed with the environment value."
-}

--- a/cudl-staging/locals.tf
+++ b/cudl-staging/locals.tf
@@ -12,6 +12,6 @@ locals {
   additional_lambda_variables = {
     AWS_DATA_SOURCE_BUCKET   = "${local.environment}-cudl-data-source"
     AWS_TRANSCRIPTION_BUCKET = "${local.environment}-cudl-transcriptions" # NOTE to be removed
-    AWS_DIST_BUCKET          = "${local.environment}-cudl-dist"
+    AWS_OUTPUT_BUCKET        = "${local.environment}-cudl-data-releases"
   }
 }

--- a/cudl-staging/main.tf
+++ b/cudl-staging/main.tf
@@ -3,7 +3,6 @@ module "cudl-data-processing" {
   chunks                          = var.chunks
   compressed-lambdas-directory    = var.compressed-lambdas-directory
   data-function-name              = var.data-function-name
-  db-lambda-information           = var.db-lambda-information
   destination-bucket-name         = var.destination-bucket-name
   dst-efs-prefix                  = var.dst-efs-prefix
   dst-prefix                      = var.dst-prefix
@@ -27,8 +26,8 @@ module "cudl-data-processing" {
   lambda-db-secret-key            = var.lambda-db-secret-key
   lambda-db-url                   = var.lambda-db-url
   aws-account-number              = var.aws-account-number
-  source-bucket-sns-notifications = var.source-bucket-sns-notifications
-  source-bucket-sqs-notifications = var.source-bucket-sqs-notifications
+  transform-lambda-bucket-sns-notifications = var.transform-lambda-bucket-sns-notifications
+  transform-lambda-bucket-sqs-notifications = var.transform-lambda-bucket-sqs-notifications
   environment                     = var.environment
   transcription-pagify-xslt       = var.transcription-pagify-xslt
   transcription-mstei-xslt        = var.transcription-mstei-xslt

--- a/cudl-staging/main.tf
+++ b/cudl-staging/main.tf
@@ -32,7 +32,7 @@ module "cudl-data-processing" {
   environment                     = var.environment
   transcription-pagify-xslt       = var.transcription-pagify-xslt
   transcription-mstei-xslt        = var.transcription-mstei-xslt
-  source-bucket-names             = [var.source-bucket-name, var.distribution-bucket-name]
+  source-bucket-name              = var.source-bucket-name
 }
 
 module "cudl-data-enhancements" {

--- a/cudl-staging/terraform.tfvars
+++ b/cudl-staging/terraform.tfvars
@@ -19,7 +19,7 @@ lambda-db-jdbc-driver                = "org.postgresql.Driver"
 lambda-db-url                        = "jdbc:postgresql://<HOST>:<PORT>/staging_cudl_viewer?autoReconnect=true"
 lambda-db-secret-key                 = "staging/cudl/cudl_viewer_db"
 
-source-bucket-sns-notifications = [
+transform-lambda-bucket-sns-notifications = [
   {
     "bucket_name"   = "cudl-data-source"
     "filter_prefix" = "items/data/tei/",
@@ -41,7 +41,7 @@ source-bucket-sns-notifications = [
   }
 ]
 
-source-bucket-sqs-notifications = [
+transform-lambda-bucket-sqs-notifications = [
   {
     "type"          = "SQS",
     "queue_name"    = "CUDLPackageDataQueue_HTML",
@@ -207,8 +207,6 @@ enhancements-lambda-information = [{
   "handler"       = "uk.ac.cam.lib.cudl.awslambda.handlers.XSLTTransformRequestHandler::handleRequest"
   "runtime"       = "java11"
 }]
-db-lambda-information = [
-]
 dst-efs-prefix              = "/mnt/cudl-data-releases"
 dst-prefix                  = "html/"
 dst-s3-prefix               = ""

--- a/cudl-staging/tests/staging.tftest.hcl
+++ b/cudl-staging/tests/staging.tftest.hcl
@@ -28,38 +28,38 @@ run "transform_lambda_sqs_queue_length" {
   }
 }
 
-run "source_item_updated_sns_topic_length" {
+run "transform_sns_topic_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_item_updated_sns_topic_length == length(var.source-bucket-sns-notifications)
+    condition     = module.cudl-data-processing.transform_sns_topic_length == length(var.transform-lambda-bucket-sns-notifications)
     error_message = "Number of SNS topics does not match expected value"
   }
 }
 
-run "item_update_topic_subscriptions_length" {
+run "transform_sns_subscriptions_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.item_update_topic_subscriptions_length == length(flatten(var.source-bucket-sns-notifications[*].subscriptions))
+    condition     = module.cudl-data-processing.transform_sns_topic_subscriptions_length == length(flatten(var.transform-lambda-bucket-sns-notifications[*].subscriptions))
     error_message = "Number of SNS topics subscriptions does not match expected value"
   }
 }
 
-run "source_bucket_notification_topics_length" {
+run "transform_bucket_notification_topics_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_bucket_notification_topics_length == length(var.source-bucket-sns-notifications)
+    condition     = module.cudl-data-processing.transform_bucket_notification_topics_length == length(var.transform-lambda-bucket-sns-notifications)
     error_message = "Number of S3 Bucket SNS topic subscriptions does not match expected value"
   }
 }
 
-run "source_bucket_notification_queues_length" {
+run "transform_bucket_notification_queues_length" {
   command = plan
 
   assert {
-    condition     = module.cudl-data-processing.source_bucket_notification_queues_length == length(var.source-bucket-sqs-notifications)
+    condition     = module.cudl-data-processing.transform_bucket_notification_queues_length == length(var.transform-lambda-bucket-sqs-notifications)
     error_message = "Number of S3 Bucket SQS Queue subscriptions does not match expected value"
   }
 }

--- a/cudl-staging/variables.tf
+++ b/cudl-staging/variables.tf
@@ -129,11 +129,6 @@ variable "enhancements-lambda-information" {
   type        = list(any)
 }
 
-variable "db-lambda-information" {
-  description = "A list of maps containing information about the database lambda functions"
-  type        = list(any)
-}
-
 variable "dst-efs-prefix" {
   description = "Use to set the DST_EFS_PREFIX variable in the properties file passed to the lambda layer"
   type        = string
@@ -219,12 +214,12 @@ variable "efs-name" {
   type        = string
 }
 
-variable "source-bucket-sns-notifications" {
-  description = "List of SNS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sns-notifications" {
+  description = "List of SNS notifications on an s3 bucket"
   type        = list(any)
 }
 
-variable "source-bucket-sqs-notifications" {
-  description = "List of SQS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sqs-notifications" {
+  description = "List of SQS notifications on an s3 bucket"
   type        = list(any)
 }

--- a/cudl-staging/variables.tf
+++ b/cudl-staging/variables.tf
@@ -228,7 +228,3 @@ variable "source-bucket-sqs-notifications" {
   description = "List of SQS notifications on source s3 bucket"
   type        = list(any)
 }
-
-variable "distribution-bucket-name" {
-  description = "The name of the s3 bucket that stores the output of the data processing pipeline. Will be prefixed with the environment value."
-}

--- a/modules/cudl-data-processing/iam.tf
+++ b/modules/cudl-data-processing/iam.tf
@@ -23,8 +23,6 @@ data "aws_iam_policy_document" "allow-get-and-list-policy" {
       "s3:GetObjectAcl"
     ]
     resources = compact(flatten([
-      aws_s3_bucket.dest-bucket.arn,
-      "${aws_s3_bucket.dest-bucket.arn}/*",
       aws_s3_bucket.transcriptions-bucket.arn,
       "${aws_s3_bucket.transcriptions-bucket.arn}/*",
       [for bucket in values(local.transform-lambda-buckets) : bucket.arn],

--- a/modules/cudl-data-processing/iam.tf
+++ b/modules/cudl-data-processing/iam.tf
@@ -27,8 +27,8 @@ data "aws_iam_policy_document" "allow-get-and-list-policy" {
       "${aws_s3_bucket.dest-bucket.arn}/*",
       aws_s3_bucket.transcriptions-bucket.arn,
       "${aws_s3_bucket.transcriptions-bucket.arn}/*",
-      [for bucket in aws_s3_bucket.transform-lambda-source-bucket : bucket.arn],
-      [for bucket in aws_s3_bucket.transform-lambda-source-bucket : "${bucket.arn}/*"]
+      [for bucket in values(local.transform-lambda-buckets) : bucket.arn],
+      [for bucket in values(local.transform-lambda-buckets) : "${bucket.arn}/*"]
     ]))
   }
   statement {

--- a/modules/cudl-data-processing/lambda.tf
+++ b/modules/cudl-data-processing/lambda.tf
@@ -68,48 +68,48 @@ resource "aws_lambda_alias" "create-transform-lambda-alias" {
   depends_on = [aws_lambda_function.create-transform-lambda-function]
 }
 
-resource "aws_lambda_function" "create-db-lambda-function" {
-  count = length(var.db-lambda-information)
+# resource "aws_lambda_function" "create-db-lambda-function" {
+#   count = length(var.db-lambda-information)
+#
+#   function_name = substr("${var.environment}-${var.db-lambda-information[count.index].name}", 0, 64)
+#   description   = var.db-lambda-information[count.index].description
+#   s3_bucket     = var.lambda-jar-bucket
+#   s3_key        = var.db-lambda-information[count.index].jar_path
+#   runtime       = var.db-lambda-information[count.index].runtime
+#   timeout       = var.db-lambda-information[count.index].timeout
+#   memory_size   = var.db-lambda-information[count.index].memory
+#   role          = aws_iam_role.assume-lambda-role.arn
+#   layers        = [aws_lambda_layer_version.db-properties-layer.arn, var.datadog-layer-1-arn, var.datadog-layer-2-arn]
+#   handler       = var.db-lambda-information[count.index].handler
+#   publish       = true
+#
+#   vpc_config {
+#     subnet_ids         = [data.aws_subnet.cudl_subnet.id]
+#     security_group_ids = [data.aws_security_group.default.id]
+#   }
+#
+#   file_system_config {
+#     arn = aws_efs_access_point.efs-access-point.arn
+#
+#     # Local mount path inside the lambda function. Must start with '/mnt/', and must not end with /
+#     local_mount_path = var.dst-efs-prefix
+#   }
+#
+#   environment {
+#     variables = var.lambda_environment_datadog_variables
+#   }
+#
+#   depends_on = [aws_efs_mount_target.efs-mount-point]
+# }
 
-  function_name = substr("${var.environment}-${var.db-lambda-information[count.index].name}", 0, 64)
-  description   = var.db-lambda-information[count.index].description
-  s3_bucket     = var.lambda-jar-bucket
-  s3_key        = var.db-lambda-information[count.index].jar_path
-  runtime       = var.db-lambda-information[count.index].runtime
-  timeout       = var.db-lambda-information[count.index].timeout
-  memory_size   = var.db-lambda-information[count.index].memory
-  role          = aws_iam_role.assume-lambda-role.arn
-  layers        = [aws_lambda_layer_version.db-properties-layer.arn, var.datadog-layer-1-arn, var.datadog-layer-2-arn]
-  handler       = var.db-lambda-information[count.index].handler
-  publish       = true
-
-  vpc_config {
-    subnet_ids         = [data.aws_subnet.cudl_subnet.id]
-    security_group_ids = [data.aws_security_group.default.id]
-  }
-
-  file_system_config {
-    arn = aws_efs_access_point.efs-access-point.arn
-
-    # Local mount path inside the lambda function. Must start with '/mnt/', and must not end with /
-    local_mount_path = var.dst-efs-prefix
-  }
-
-  environment {
-    variables = var.lambda_environment_datadog_variables
-  }
-
-  depends_on = [aws_efs_mount_target.efs-mount-point]
-}
-
-resource "aws_lambda_alias" "create-db-lambda-alias" {
-  count = length(var.db-lambda-information)
-
-  name          = var.lambda-alias-name
-  function_name = aws_lambda_function.create-db-lambda-function[count.index].arn
-  #function_version = var.db-lambda-information[count.index].live_version
-  function_version = aws_lambda_function.create-db-lambda-function[count.index].version
-}
+# resource "aws_lambda_alias" "create-db-lambda-alias" {
+#   count = length(var.db-lambda-information)
+#
+#   name          = var.lambda-alias-name
+#   function_name = aws_lambda_function.create-db-lambda-function[count.index].arn
+#   #function_version = var.db-lambda-information[count.index].live_version
+#   function_version = aws_lambda_function.create-db-lambda-function[count.index].version
+# }
 
 resource "local_file" "create-local-lambda-properties-file" {
 
@@ -209,9 +209,9 @@ resource "aws_lambda_event_source_mapping" "sqs-trigger-lambda-transforms" {
   }
 }
 
-resource "aws_lambda_event_source_mapping" "sqs-trigger-lambda-db" {
-  count = length(var.db-lambda-information)
-
-  event_source_arn = aws_sqs_queue.db-lambda-sqs-queue[count.index].arn
-  function_name    = aws_lambda_function.create-db-lambda-function[count.index].arn
-}
+# resource "aws_lambda_event_source_mapping" "sqs-trigger-lambda-db" {
+#   count = length(var.db-lambda-information)
+#
+#   event_source_arn = aws_sqs_queue.db-lambda-sqs-queue[count.index].arn
+#   function_name    = aws_lambda_function.create-db-lambda-function[count.index].arn
+# }

--- a/modules/cudl-data-processing/lambda.tf
+++ b/modules/cudl-data-processing/lambda.tf
@@ -68,49 +68,6 @@ resource "aws_lambda_alias" "create-transform-lambda-alias" {
   depends_on = [aws_lambda_function.create-transform-lambda-function]
 }
 
-# resource "aws_lambda_function" "create-db-lambda-function" {
-#   count = length(var.db-lambda-information)
-#
-#   function_name = substr("${var.environment}-${var.db-lambda-information[count.index].name}", 0, 64)
-#   description   = var.db-lambda-information[count.index].description
-#   s3_bucket     = var.lambda-jar-bucket
-#   s3_key        = var.db-lambda-information[count.index].jar_path
-#   runtime       = var.db-lambda-information[count.index].runtime
-#   timeout       = var.db-lambda-information[count.index].timeout
-#   memory_size   = var.db-lambda-information[count.index].memory
-#   role          = aws_iam_role.assume-lambda-role.arn
-#   layers        = [aws_lambda_layer_version.db-properties-layer.arn, var.datadog-layer-1-arn, var.datadog-layer-2-arn]
-#   handler       = var.db-lambda-information[count.index].handler
-#   publish       = true
-#
-#   vpc_config {
-#     subnet_ids         = [data.aws_subnet.cudl_subnet.id]
-#     security_group_ids = [data.aws_security_group.default.id]
-#   }
-#
-#   file_system_config {
-#     arn = aws_efs_access_point.efs-access-point.arn
-#
-#     # Local mount path inside the lambda function. Must start with '/mnt/', and must not end with /
-#     local_mount_path = var.dst-efs-prefix
-#   }
-#
-#   environment {
-#     variables = var.lambda_environment_datadog_variables
-#   }
-#
-#   depends_on = [aws_efs_mount_target.efs-mount-point]
-# }
-
-# resource "aws_lambda_alias" "create-db-lambda-alias" {
-#   count = length(var.db-lambda-information)
-#
-#   name          = var.lambda-alias-name
-#   function_name = aws_lambda_function.create-db-lambda-function[count.index].arn
-#   #function_version = var.db-lambda-information[count.index].live_version
-#   function_version = aws_lambda_function.create-db-lambda-function[count.index].version
-# }
-
 resource "local_file" "create-local-lambda-properties-file" {
 
   content = <<-EOT
@@ -169,17 +126,7 @@ resource "aws_lambda_layer_version" "transform-properties-layer" {
   layer_name       = "${var.environment}-properties"
   source_code_hash = data.archive_file.zip_transform_properties_lambda_layer.output_base64sha256
 
-  compatible_runtimes = compact(distinct([for lambda in concat(var.transform-lambda-information, var.db-lambda-information) : lambda.runtime]))
-  depends_on          = [data.archive_file.zip_transform_properties_lambda_layer]
-}
-
-resource "aws_lambda_layer_version" "db-properties-layer" {
-
-  filename         = "${path.module}/zipped_properties_files/${var.environment}.properties.zip"
-  layer_name       = "${var.environment}-properties"
-  source_code_hash = data.archive_file.zip_transform_properties_lambda_layer.output_base64sha256
-
-  compatible_runtimes = compact(distinct([for lambda in concat(var.transform-lambda-information, var.db-lambda-information) : lambda.runtime]))
+  compatible_runtimes = compact(distinct([for lambda in var.transform-lambda-information : lambda.runtime]))
   depends_on          = [data.archive_file.zip_transform_properties_lambda_layer]
 }
 
@@ -188,7 +135,7 @@ resource "aws_lambda_layer_version" "xslt-layer" {
   s3_key     = var.lambda-layer-filepath
   layer_name = "${var.environment}-${var.lambda-layer-name}"
 
-  compatible_runtimes = compact(distinct([for lambda in concat(var.transform-lambda-information, var.db-lambda-information) : lambda.runtime]))
+  compatible_runtimes = compact(distinct([for lambda in var.transform-lambda-information : lambda.runtime]))
 }
 
 # Trigger lambda from the SQS queues
@@ -208,10 +155,3 @@ resource "aws_lambda_event_source_mapping" "sqs-trigger-lambda-transforms" {
     }
   }
 }
-
-# resource "aws_lambda_event_source_mapping" "sqs-trigger-lambda-db" {
-#   count = length(var.db-lambda-information)
-#
-#   event_source_arn = aws_sqs_queue.db-lambda-sqs-queue[count.index].arn
-#   function_name    = aws_lambda_function.create-db-lambda-function[count.index].arn
-# }

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -2,26 +2,24 @@ locals {
 
   transform-lambda-bucket-names = toset([var.source-bucket-name, var.destination-bucket-name])
 
-  source_sns_subscriptions = flatten([
-    for notification in var.source-bucket-sns-notifications : [
+  transform_sns_subscriptions = flatten([
+    for notification in var.transform-lambda-bucket-sns-notifications : [
       for subscription in notification.subscriptions : merge(subscription, { bucket_name = notification.bucket_name })
     ]
   ])
-  source_bucket_sns_notifications = {
-    for notification in var.source-bucket-sns-notifications : notification.bucket_name => {
+  transform_bucket_sns_notifications = {
+    for notification in var.transform-lambda-bucket-sns-notifications : notification.bucket_name => {
       filter_prefix = notification.filter_prefix
       filter_suffix = notification.filter_suffix
       queue_names   = [for subscription in notification.subscriptions : subscription.queue_name]
     } if contains(local.transform-lambda-bucket-names, notification.bucket_name)
   }
-  source_bucket_sqs_notifications = {
+  transform_bucket_sqs_notifications = {
     for bucket in local.transform-lambda-bucket-names : bucket => [
-      for notification in var.source-bucket-sqs-notifications : notification if notification.bucket_name == bucket
+      for notification in var.transform-lambda-bucket-sqs-notifications : notification if notification.bucket_name == bucket
     ]
   }
   transform_lambda_queues = toset([for lambda in var.transform-lambda-information : lambda.queue_name])
-
-
 
   transform-lambda-buckets = {
     for bucket in toset([aws_s3_bucket.source-bucket, aws_s3_bucket.dest-bucket]) :

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -1,4 +1,7 @@
 locals {
+
+  transform-lambda-bucket-names = toset([var.source-bucket-name, var.destination-bucket-name])
+
   source_sns_subscriptions = flatten([
     for notification in var.source-bucket-sns-notifications : [
       for subscription in notification.subscriptions : merge(subscription, { bucket_name = notification.bucket_name })
@@ -9,12 +12,20 @@ locals {
       filter_prefix = notification.filter_prefix
       filter_suffix = notification.filter_suffix
       queue_names   = [for subscription in notification.subscriptions : subscription.queue_name]
-    } if contains(var.source-bucket-names, notification.bucket_name)
+    } if contains(local.transform-lambda-bucket-names, notification.bucket_name)
   }
   source_bucket_sqs_notifications = {
-    for bucket in toset(var.source-bucket-names) : bucket => [
+    for bucket in local.transform-lambda-bucket-names : bucket => [
       for notification in var.source-bucket-sqs-notifications : notification if notification.bucket_name == bucket
     ]
   }
   transform_lambda_queues = toset([for lambda in var.transform-lambda-information : lambda.queue_name])
+
+
+
+  transform-lambda-buckets = {
+    for bucket in toset([aws_s3_bucket.source-bucket, aws_s3_bucket.dest-bucket]) :
+      replace(bucket.id, lower("${var.environment}-"), "") => bucket
+  }
+
 }

--- a/modules/cudl-data-processing/outputs.tf
+++ b/modules/cudl-data-processing/outputs.tf
@@ -6,18 +6,18 @@ output "transform_lambda_sqs_queue_length" {
   value = length(aws_sqs_queue.transform-lambda-sqs-queue)
 }
 
-output "source_item_updated_sns_topic_length" {
-  value = length(aws_sns_topic.source_item_updated)
+output "transform_sns_topic_length" {
+  value = length(aws_sns_topic.transform_sns_topics)
 }
 
-output "item_update_topic_subscriptions_length" {
-  value = length(aws_sns_topic_subscription.item_update_subscriptions)
+output "transform_sns_topic_subscriptions_length" {
+  value = length(aws_sns_topic_subscription.transform_sns_event_subscriptions)
 }
 
-output "source_bucket_notification_topics_length" {
-  value = length(flatten([for notification in aws_s3_bucket_notification.source-bucket-notifications : [for topic in notification.topic : topic.topic_arn]]))
+output "transform_bucket_notification_topics_length" {
+  value = length(flatten([for notification in aws_s3_bucket_notification.transform-lambda-bucket-notifications : [for topic in notification.topic : topic.topic_arn]]))
 }
 
-output "source_bucket_notification_queues_length" {
-  value = length(flatten([for notification in aws_s3_bucket_notification.source-bucket-notifications : [for queue in notification.queue : queue.queue_arn]]))
+output "transform_bucket_notification_queues_length" {
+  value = length(flatten([for notification in aws_s3_bucket_notification.transform-lambda-bucket-notifications : [for queue in notification.queue : queue.queue_arn]]))
 }

--- a/modules/cudl-data-processing/s3.tf
+++ b/modules/cudl-data-processing/s3.tf
@@ -31,12 +31,6 @@ resource "aws_s3_bucket_versioning" "transform-lambda-source-bucket-versioning" 
     status = "Suspended"
   }
 }
-resource "aws_s3_bucket_versioning" "dest-bucket-versioning" {
-  bucket = aws_s3_bucket.dest-bucket.id
-  versioning_configuration {
-    status = "Suspended"
-  }
-}
 
 resource "aws_s3_bucket_versioning" "transcriptions-bucket-versioning" {
   bucket = aws_s3_bucket.transcriptions-bucket.id
@@ -45,24 +39,24 @@ resource "aws_s3_bucket_versioning" "transcriptions-bucket-versioning" {
   }
 }
 
-resource "aws_s3_bucket_notification" "source-bucket-notifications" {
+resource "aws_s3_bucket_notification" "transform-lambda-bucket-notifications" {
   for_each = local.transform-lambda-bucket-names
   bucket = local.transform-lambda-buckets[each.key].id
 
   # Add a topic if there is an SNS topic relating to the bucket (the keys of
   # local.source_bucket_s3_notifications)
   dynamic "topic" {
-    for_each = contains(keys(local.source_bucket_sns_notifications), each.key) ? [1] : []
+    for_each = contains(keys(local.transform_bucket_sns_notifications), each.key) ? [1] : []
     content {
-      topic_arn     = aws_sns_topic.source_item_updated[each.key].arn
+      topic_arn     = aws_sns_topic.transform_sns_topics[each.key].arn
       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-      filter_prefix = local.source_bucket_sns_notifications[each.key].filter_prefix
-      filter_suffix = local.source_bucket_sns_notifications[each.key].filter_suffix
+      filter_prefix = local.transform_bucket_sns_notifications[each.key].filter_prefix
+      filter_suffix = local.transform_bucket_sns_notifications[each.key].filter_suffix
     }
   }
 
   dynamic "queue" {
-    for_each = local.source_bucket_sqs_notifications[each.key]
+    for_each = local.transform_bucket_sqs_notifications[each.key]
     content {
       queue_arn     = aws_sqs_queue.transform-lambda-sqs-queue[queue.value.queue_name].arn
       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
@@ -73,103 +67,5 @@ resource "aws_s3_bucket_notification" "source-bucket-notifications" {
 
   # without the `depends_on` argument, the bucket notification creation fails because the
   # lambda function doesn't exist yet
-  depends_on = [aws_sqs_queue.transform-lambda-sqs-queue, aws_lambda_function.create-transform-lambda-function, aws_sns_topic.source_item_updated]
+  depends_on = [aws_sqs_queue.transform-lambda-sqs-queue, aws_lambda_function.create-transform-lambda-function, aws_sns_topic.transform_sns_topics]
 }
-
-/*locals {
-  # Some of the buckets have multiple filters that should trigger notifications
-  # So we sort out the filters and create them as additional notifications
-  other_filter_map = distinct(flatten([
-  for lambda in var.transform-lambda-information : [
-  for filter in split("|", lambda.other_filters) : {
-    queue_index   = index(var.transform-lambda-information, lambda)
-    filter_suffix = filter
-  }] if try(lambda.other_filters, "") != ""
-  ]))
-
- # other-cidr-blocks = length(var.cidr-blocks) > 1 ? toset(slice(var.cidr-blocks, 1, length(var.cidr-blocks))) : toset([])
-}*/
-
-/*resource "aws_s3_bucket_notification" "additional-source-bucket-notifications" {
-  for_each = {
-  for filter in local.other_filter_map : filter.filter_suffix => filter.queue_index
-  }
-
-  bucket = aws_s3_bucket.source-bucket.id
-
-  queue {
-    queue_arn     = aws_sqs_queue.transform-lambda-sqs-queue[each.value].arn
-    events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-    filter_suffix = each.key
-  }
-
-  # without the `depends_on` argument, the bucket notification creation fails because the
-  # lambda function doesn't exist yet
-  depends_on = [aws_lambda_function.create-transform-lambda-function, aws_sqs_queue.transform-lambda-sqs-queue]
-}*/
-
-# // TODO also temp. hack to get multiple triggers working on a single bucket.
-# resource "aws_s3_bucket_notification" "dest-bucket-notifications" {
-#   #count  = length(var.db-lambda-information)
-#   bucket = aws_s3_bucket.dest-bucket.id
-#
-#   dynamic "queue" {
-#     for_each = aws_sqs_queue.db-lambda-sqs-queue
-#     content {
-#       queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[each.key].arn
-#       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-#       filter_prefix = try(var.db-lambda-information[0].filter_prefix, "") != "" ?
-#         var.db-lambda-information[0].filter_prefix : null
-#       filter_suffix = try(var.db-lambda-information[0].filter_suffix, "") != "" ?
-#         var.db-lambda-information[0].filter_suffix : null
-#     }
-#   }
-#
-#   queue {
-#     queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[1].arn
-#     events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-#     filter_prefix = try(var.db-lambda-information[1].filter_prefix, "") != "" ? var.db-lambda-information[1].filter_prefix : null
-#     filter_suffix = try(var.db-lambda-information[1].filter_suffix, "") != "" ? var.db-lambda-information[1].filter_suffix : null
-#   }
-#
-#   queue {
-#     queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[2].arn
-#     events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-#     filter_prefix = try(var.db-lambda-information[2].filter_prefix, "") != "" ? var.db-lambda-information[2].filter_prefix : null
-#     filter_suffix = try(var.db-lambda-information[2].filter_suffix, "") != "" ? var.db-lambda-information[2].filter_suffix : null
-#   }
-#   # without the `depends_on` argument, the bucket notification creation fails because the
-#   # lambda function doesn't exist yet
-#   depends_on = [aws_lambda_function.create-db-lambda-function]
-# }
-
-# resource "aws_s3_bucket_notification" "dest-bucket-notifications" {
-#
-#   bucket = aws_s3_bucket.dest-bucket.id
-#
-#   # Add a topic if there is an SNS topic relating to the bucket (the keys of
-#   # local.source_bucket_s3_notifications)
-#   dynamic "topic" {
-#     for_each = contains(keys(local.dest_bucket_sns_notifications), var.destination-bucket-name) ? [1] : []
-#     content {
-#       topic_arn     = aws_sns_topic.source_item_updated[var.destination-bucket-name].arn
-#       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-#       filter_prefix = local.source_bucket_sns_notifications[var.destination-bucket-name].filter_prefix
-#       filter_suffix = local.source_bucket_sns_notifications[var.destination-bucket-name].filter_suffix
-#     }
-#   }
-#
-#   dynamic "queue" {
-#     for_each = local.source_bucket_sqs_notifications[var.source-bucket-name]
-#     content {
-#       queue_arn     = aws_sqs_queue.transform-lambda-sqs-queue[queue.value.queue_name].arn
-#       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-#       filter_prefix = try(queue.value.filter_prefix, null)
-#       filter_suffix = try(queue.value.filter_suffix, null)
-#     }
-#   }
-#
-#   # without the `depends_on` argument, the bucket notification creation fails because the
-#   # lambda function doesn't exist yet
-#   depends_on = [aws_sqs_queue.transform-lambda-sqs-queue, aws_lambda_function.create-transform-lambda-function, aws_sns_topic.source_item_updated]
-# }

--- a/modules/cudl-data-processing/s3.tf
+++ b/modules/cudl-data-processing/s3.tf
@@ -2,14 +2,14 @@ resource "aws_s3_bucket" "dest-bucket" {
   bucket = lower("${var.environment}-${var.destination-bucket-name}")
 }
 
+resource "aws_s3_bucket" "source-bucket" {
+  bucket = lower("${var.environment}-${var.source-bucket-name}")
+}
+
 resource "aws_s3_bucket" "transcriptions-bucket" {
   bucket = lower("${var.environment}-${var.transcriptions-bucket-name}")
 }
 
-resource "aws_s3_bucket" "transform-lambda-source-bucket" {
-  for_each = toset(var.source-bucket-names)
-  bucket   = lower("${var.environment}-${each.key}")
-}
 
 resource "aws_s3_bucket_website_configuration" "example" {
   bucket = aws_s3_bucket.transcriptions-bucket.id
@@ -24,8 +24,9 @@ resource "aws_s3_bucket_website_configuration" "example" {
 }
 
 resource "aws_s3_bucket_versioning" "transform-lambda-source-bucket-versioning" {
-  for_each = aws_s3_bucket.transform-lambda-source-bucket
-  bucket   = aws_s3_bucket.transform-lambda-source-bucket[each.key].id
+  for_each = local.transform-lambda-bucket-names
+  bucket   = local.transform-lambda-buckets[each.key].id
+
   versioning_configuration {
     status = "Suspended"
   }
@@ -45,9 +46,8 @@ resource "aws_s3_bucket_versioning" "transcriptions-bucket-versioning" {
 }
 
 resource "aws_s3_bucket_notification" "source-bucket-notifications" {
-  for_each = toset(var.source-bucket-names)
-
-  bucket = aws_s3_bucket.transform-lambda-source-bucket[each.key].id
+  for_each = local.transform-lambda-bucket-names
+  bucket = local.transform-lambda-buckets[each.key].id
 
   # Add a topic if there is an SNS topic relating to the bucket (the keys of
   # local.source_bucket_s3_notifications)
@@ -108,32 +108,68 @@ resource "aws_s3_bucket_notification" "source-bucket-notifications" {
   depends_on = [aws_lambda_function.create-transform-lambda-function, aws_sqs_queue.transform-lambda-sqs-queue]
 }*/
 
-// TODO also temp. hack to get multiple triggers working on a single bucket.
-resource "aws_s3_bucket_notification" "dest-bucket-notifications" {
-  #count  = length(var.db-lambda-information)
-  bucket = aws_s3_bucket.dest-bucket.id
+# // TODO also temp. hack to get multiple triggers working on a single bucket.
+# resource "aws_s3_bucket_notification" "dest-bucket-notifications" {
+#   #count  = length(var.db-lambda-information)
+#   bucket = aws_s3_bucket.dest-bucket.id
+#
+#   dynamic "queue" {
+#     for_each = aws_sqs_queue.db-lambda-sqs-queue
+#     content {
+#       queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[each.key].arn
+#       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+#       filter_prefix = try(var.db-lambda-information[0].filter_prefix, "") != "" ?
+#         var.db-lambda-information[0].filter_prefix : null
+#       filter_suffix = try(var.db-lambda-information[0].filter_suffix, "") != "" ?
+#         var.db-lambda-information[0].filter_suffix : null
+#     }
+#   }
+#
+#   queue {
+#     queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[1].arn
+#     events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+#     filter_prefix = try(var.db-lambda-information[1].filter_prefix, "") != "" ? var.db-lambda-information[1].filter_prefix : null
+#     filter_suffix = try(var.db-lambda-information[1].filter_suffix, "") != "" ? var.db-lambda-information[1].filter_suffix : null
+#   }
+#
+#   queue {
+#     queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[2].arn
+#     events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+#     filter_prefix = try(var.db-lambda-information[2].filter_prefix, "") != "" ? var.db-lambda-information[2].filter_prefix : null
+#     filter_suffix = try(var.db-lambda-information[2].filter_suffix, "") != "" ? var.db-lambda-information[2].filter_suffix : null
+#   }
+#   # without the `depends_on` argument, the bucket notification creation fails because the
+#   # lambda function doesn't exist yet
+#   depends_on = [aws_lambda_function.create-db-lambda-function]
+# }
 
-  queue {
-    queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[0].arn
-    events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-    filter_prefix = try(var.db-lambda-information[0].filter_prefix, "") != "" ? var.db-lambda-information[0].filter_prefix : null
-    filter_suffix = try(var.db-lambda-information[0].filter_suffix, "") != "" ? var.db-lambda-information[0].filter_suffix : null
-  }
-
-  queue {
-    queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[1].arn
-    events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-    filter_prefix = try(var.db-lambda-information[1].filter_prefix, "") != "" ? var.db-lambda-information[1].filter_prefix : null
-    filter_suffix = try(var.db-lambda-information[1].filter_suffix, "") != "" ? var.db-lambda-information[1].filter_suffix : null
-  }
-
-  queue {
-    queue_arn     = aws_sqs_queue.db-lambda-sqs-queue[2].arn
-    events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-    filter_prefix = try(var.db-lambda-information[2].filter_prefix, "") != "" ? var.db-lambda-information[2].filter_prefix : null
-    filter_suffix = try(var.db-lambda-information[2].filter_suffix, "") != "" ? var.db-lambda-information[2].filter_suffix : null
-  }
-  # without the `depends_on` argument, the bucket notification creation fails because the
-  # lambda function doesn't exist yet
-  depends_on = [aws_lambda_function.create-db-lambda-function]
-}
+# resource "aws_s3_bucket_notification" "dest-bucket-notifications" {
+#
+#   bucket = aws_s3_bucket.dest-bucket.id
+#
+#   # Add a topic if there is an SNS topic relating to the bucket (the keys of
+#   # local.source_bucket_s3_notifications)
+#   dynamic "topic" {
+#     for_each = contains(keys(local.dest_bucket_sns_notifications), var.destination-bucket-name) ? [1] : []
+#     content {
+#       topic_arn     = aws_sns_topic.source_item_updated[var.destination-bucket-name].arn
+#       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+#       filter_prefix = local.source_bucket_sns_notifications[var.destination-bucket-name].filter_prefix
+#       filter_suffix = local.source_bucket_sns_notifications[var.destination-bucket-name].filter_suffix
+#     }
+#   }
+#
+#   dynamic "queue" {
+#     for_each = local.source_bucket_sqs_notifications[var.source-bucket-name]
+#     content {
+#       queue_arn     = aws_sqs_queue.transform-lambda-sqs-queue[queue.value.queue_name].arn
+#       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+#       filter_prefix = try(queue.value.filter_prefix, null)
+#       filter_suffix = try(queue.value.filter_suffix, null)
+#     }
+#   }
+#
+#   # without the `depends_on` argument, the bucket notification creation fails because the
+#   # lambda function doesn't exist yet
+#   depends_on = [aws_sqs_queue.transform-lambda-sqs-queue, aws_lambda_function.create-transform-lambda-function, aws_sns_topic.source_item_updated]
+# }

--- a/modules/cudl-data-processing/sns.tf
+++ b/modules/cudl-data-processing/sns.tf
@@ -12,7 +12,7 @@ resource "aws_sns_topic" "source_item_updated" {
         "Resource": "arn:aws:sns:*:*:${var.environment}-${each.key}-event-notification-topic",
         "Condition": {
             "ArnLike": {
-                "aws:SourceArn": "${aws_s3_bucket.transform-lambda-source-bucket[each.key].arn}"
+                "aws:SourceArn": "${local.transform-lambda-buckets[each.key].arn}"
             }
         }
     }]

--- a/modules/cudl-data-processing/sns.tf
+++ b/modules/cudl-data-processing/sns.tf
@@ -1,5 +1,5 @@
-resource "aws_sns_topic" "source_item_updated" {
-  for_each = local.source_bucket_sns_notifications
+resource "aws_sns_topic" "transform_sns_topics" {
+  for_each = local.transform_bucket_sns_notifications
 
   name   = "${var.environment}-${each.key}-event-notification-topic"
   policy = <<POLICY
@@ -21,11 +21,11 @@ POLICY
 }
 
 # NOTE need a separate local variable for the loop here as Terraform can't do resources with nested for_each blocks
-resource "aws_sns_topic_subscription" "item_update_subscriptions" {
-  count = length(local.source_sns_subscriptions)
+resource "aws_sns_topic_subscription" "transform_sns_event_subscriptions" {
+  count = length(local.transform_sns_subscriptions)
 
-  topic_arn            = aws_sns_topic.source_item_updated[local.source_sns_subscriptions[count.index].bucket_name].arn
+  topic_arn            = aws_sns_topic.transform_sns_topics[local.transform_sns_subscriptions[count.index].bucket_name].arn
   protocol             = "sqs"
-  raw_message_delivery = local.source_sns_subscriptions[count.index].raw
-  endpoint             = aws_sqs_queue.transform-lambda-sqs-queue[local.source_sns_subscriptions[count.index].queue_name].arn
+  raw_message_delivery = local.transform_sns_subscriptions[count.index].raw
+  endpoint             = aws_sqs_queue.transform-lambda-sqs-queue[local.transform_sns_subscriptions[count.index].queue_name].arn
 }

--- a/modules/cudl-data-processing/sqs.tf
+++ b/modules/cudl-data-processing/sqs.tf
@@ -17,7 +17,7 @@ resource "aws_sqs_queue" "transform-lambda-sqs-queue" {
         Resource = "arn:aws:sqs:*:*:${substr("${var.environment}-${each.key}", 0, 64)}"
         Condition = {
           ArnEquals = {
-            "aws:SourceArn" = [for bucket in aws_s3_bucket.transform-lambda-source-bucket : bucket.arn]
+            "aws:SourceArn" = [for bucket in values(local.transform-lambda-buckets) : bucket.arn]
           }
         }
       },

--- a/modules/cudl-data-processing/sqs.tf
+++ b/modules/cudl-data-processing/sqs.tf
@@ -40,48 +40,9 @@ resource "aws_sqs_queue" "transform-lambda-sqs-queue" {
   })
 }
 
-resource "aws_sqs_queue" "db-lambda-sqs-queue" {
-  count = length(var.db-lambda-information)
-
-  name = substr("${var.environment}-${var.db-lambda-information[count.index].queue_name}", 0, 64)
-
-  visibility_timeout_seconds = 900
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "s3.amazonaws.com"
-      },
-      "Action": "sqs:SendMessage",
-      "Resource": "arn:aws:sqs:*:*:${substr("${var.environment}-${var.db-lambda-information[count.index].queue_name}", 0, 64)}",
-      "Condition": {
-        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.dest-bucket.arn}" }
-      }
-    }
-  ]
-}
-POLICY
-
-  redrive_policy = jsonencode({
-    "deadLetterTargetArn" = aws_sqs_queue.db-lambda-dead-letter-queue[count.index].arn,
-    "maxReceiveCount"     = 3
-  })
-}
-
-
-
 resource "aws_sqs_queue" "transform-lambda-dead-letter-queue" {
   for_each                   = local.transform_lambda_queues
   visibility_timeout_seconds = 900
   name                       = substr("${var.environment}-${each.key}_DeadLetterQueue", 0, 80)
 }
 
-resource "aws_sqs_queue" "db-lambda-dead-letter-queue" {
-  count                      = length(var.db-lambda-information)
-  visibility_timeout_seconds = 900
-  name                       = substr("${var.environment}-${var.db-lambda-information[count.index].queue_name}_DeadLetterQueue", 0, 80)
-}

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -14,10 +14,9 @@ variable "environment" {
   type        = string
 }
 
-variable "source-bucket-names" {
-  description = "List of source buckets used to create triggers."
-  type        = list(string)
-  default     = []
+variable "source-bucket-name" {
+  description = "The name of the s3 bucket that is used as a data source to trigger transformation."
+  type        = string
 }
 
 variable "destination-bucket-name" {

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -113,10 +113,10 @@ variable "default-lambda-security-group" {
   default     = "default"
 }
 
-variable "db-lambda-information" {
-  description = "A list of maps containing information about the database lambda functions"
-  type        = list(any)
-}
+# variable "db-lambda-information" {
+#   description = "A list of maps containing information about the database lambda functions"
+#   type        = list(any)
+# }
 
 variable "dst-efs-prefix" {
   description = "Use to set the DST_EFS_PREFIX variable in the properties file passed to the lambda layer"
@@ -198,13 +198,13 @@ variable "efs-name" {
   type        = string
 }
 
-variable "source-bucket-sns-notifications" {
-  description = "List of SNS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sns-notifications" {
+  description = "List of SNS notifications an s3 bucket"
   type        = list(any)
 }
 
-variable "source-bucket-sqs-notifications" {
-  description = "List of SQS notifications on source s3 bucket"
+variable "transform-lambda-bucket-sqs-notifications" {
+  description = "List of SQS notifications an s3 bucket"
   type        = list(any)
 }
 


### PR DESCRIPTION
This updates includes the following: 

- Refactor: Make a single list of lambdas in the configuration, and event listeners instead of having a separate list for the lambdas related to DB Updates.
- Refactor: Remove the property listing source buckets, and instead support a list of all buckets, supporting the configuration above.
- Feat: Remove the references to dist bucket and update the properties to point to cudl-data-releases instead.
- Update the image and properties for the image lambdas.
- Bugfix: Update the subnet used by the Java lambdas so they are able to access the network. 

Testing with the https://github.com/cambridge-collection/cudl-testing-data-processing-workflow shows that the items and collections are copied to the correct buckets and inspecting the event notifications it looks correct. We will need further testing for indexing. 