### PR TITLE
Updating to add support for multiple sns per bucket

### DIFF
--- a/cudl-dev/terraform.tfvars
+++ b/cudl-dev/terraform.tfvars
@@ -42,6 +42,21 @@ transform-lambda-bucket-sns-notifications = [
         "raw"        = true
       },
     ]
+  },
+  {
+    "bucket_name"   = "cudl-data-releases"
+    "filter_prefix" = "cudl.ui.json",
+    "filter_suffix" = ""
+    "subscriptions" = [
+      {
+        "queue_name" = "CUDLPackageDataUIQueue",
+        "raw"        = true
+      },
+      {
+        "queue_name" = "CUDLPackageDataCopyFileToEFSQueue",
+        "raw"        = true
+      },
+    ]
   }
 ]
 transform-lambda-bucket-sqs-notifications = [
@@ -97,13 +112,6 @@ transform-lambda-bucket-sqs-notifications = [
     "type"          = "SQS",
     "queue_name"    = "CUDLPackageDataDatasetQueue"
     "filter_prefix" = "cudl.dl-dataset.json"
-    "filter_suffix" = ""
-    "bucket_name"   = "cudl-data-releases"
-  },
-  {
-    "type"          = "SQS",
-    "queue_name"    = "CUDLPackageDataUIQueue"
-    "filter_prefix" = "cudl.ui.json"
     "filter_suffix" = ""
     "bucket_name"   = "cudl-data-releases"
   },
@@ -182,7 +190,7 @@ transform-lambda-information = [
   },
   {
     "name"                     = "AWSLambda_CUDLPackageData_TEI_Processing"
-    "image_uri"                = "247242244017.dkr.ecr.eu-west-1.amazonaws.com/cudl-tei-processing@sha256:367706710d9e68693e256c2737349b1750a75c274641036d2d1400dd00ef63df"
+    "image_uri"                = "247242244017.dkr.ecr.eu-west-1.amazonaws.com/cudl-tei-processing@sha256:198b3946d4d215e6093a474442d075cece37c8c9d734121acf8b6c1ec553c7a7"
     "queue_name"               = "CUDL_TEIProcessingQueue"
     "vpc_name"                 = "CUDL-NETBLOCK"
     "subnet_names"             = ["CUDL-EUW1A"]

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -6,8 +6,8 @@ locals {
     for index, notification in var.transform-lambda-bucket-sns-notifications : [
       for subscription in notification.subscriptions : merge(subscription, {
         bucket_name = notification.bucket_name,
-        topic_name = replace(lower(format("%s-%s-%s", notification.bucket_name,
-        notification.filter_prefix, notification.filter_suffix)), "/[^0-9a-z_-]/", "")
+        topic_name = replace(lower(join("-", compact([notification.bucket_name,
+        notification.filter_prefix, notification.filter_suffix]))), "/[^0-9a-z_-]/", "")
       })
     ]
   ])
@@ -17,8 +17,9 @@ locals {
   There is unlikely possibility of this being a duplicate in the future, but I think it will do as a reference for now.
    */
   transform_bucket_sns_notifications = {
-    for index, notification in var.transform-lambda-bucket-sns-notifications : replace(lower(format("%s-%s-%s",
-      notification.bucket_name, notification.filter_prefix, notification.filter_suffix)), "/[^0-9a-z_-]/", "") => {
+    for index, notification in var.transform-lambda-bucket-sns-notifications : replace(lower(join("-",
+      compact([notification.bucket_name, notification.filter_prefix, notification.filter_suffix]))),
+      "/[^0-9a-z_-]/", "") => {
       bucket_name   = notification.bucket_name
       filter_prefix = notification.filter_prefix
       filter_suffix = notification.filter_suffix

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -3,12 +3,23 @@ locals {
   transform-lambda-bucket-names = toset([var.source-bucket-name, var.destination-bucket-name, var.enhancements-bucket-name])
 
   transform_sns_subscriptions = flatten([
-    for notification in var.transform-lambda-bucket-sns-notifications : [
-      for subscription in notification.subscriptions : merge(subscription, { bucket_name = notification.bucket_name })
+    for index, notification in var.transform-lambda-bucket-sns-notifications : [
+      for subscription in notification.subscriptions : merge(subscription, {
+        bucket_name = notification.bucket_name,
+        topic_name = replace(lower(format("%s-%s-%s", notification.bucket_name,
+        notification.filter_prefix, notification.filter_suffix)), "/[^0-9a-z_-]/", "")
+      })
     ]
   ])
+  /*
+  We're going to use a formatted name specific to the bucket and prefix, suffix used as a topic name.
+  There will be multiple topics per bucket, with different prefix / suffixes so this should describe them well.
+  There is unlikely possibility of this being a duplicate in the future, but I think it will do as a reference for now.
+   */
   transform_bucket_sns_notifications = {
-    for notification in var.transform-lambda-bucket-sns-notifications : notification.bucket_name => {
+    for index, notification in var.transform-lambda-bucket-sns-notifications : replace(lower(format("%s-%s-%s",
+      notification.bucket_name, notification.filter_prefix, notification.filter_suffix)), "/[^0-9a-z_-]/", "") => {
+      bucket_name   = notification.bucket_name
       filter_prefix = notification.filter_prefix
       filter_suffix = notification.filter_suffix
       queue_names   = [for subscription in notification.subscriptions : subscription.queue_name]

--- a/modules/cudl-data-processing/s3.tf
+++ b/modules/cudl-data-processing/s3.tf
@@ -54,12 +54,12 @@ resource "aws_s3_bucket_notification" "transform-lambda-bucket-notifications" {
   # Add a topic if there is an SNS topic relating to the bucket (the keys of
   # local.source_bucket_s3_notifications)
   dynamic "topic" {
-    for_each = contains(keys(local.transform_bucket_sns_notifications), each.key) ? [1] : []
+    for_each = { for k, v in local.transform_bucket_sns_notifications : k => v if local.transform_bucket_sns_notifications[k].bucket_name == each.key }
     content {
-      topic_arn     = aws_sns_topic.transform_sns_topics[each.key].arn
+      topic_arn     = aws_sns_topic.transform_sns_topics[topic.key].arn
       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-      filter_prefix = local.transform_bucket_sns_notifications[each.key].filter_prefix
-      filter_suffix = local.transform_bucket_sns_notifications[each.key].filter_suffix
+      filter_prefix = try(topic.value.filter_prefix, null)
+      filter_suffix = try(topic.value.filter_suffix, null)
     }
   }
 

--- a/modules/cudl-data-processing/sns.tf
+++ b/modules/cudl-data-processing/sns.tf
@@ -12,7 +12,7 @@ resource "aws_sns_topic" "transform_sns_topics" {
         "Resource": "arn:aws:sns:*:*:${var.environment}-${each.key}-event-notification-topic",
         "Condition": {
             "ArnLike": {
-                "aws:SourceArn": "${local.transform-lambda-buckets[each.key].arn}"
+                "aws:SourceArn": "${local.transform-lambda-buckets[each.value.bucket_name].arn}"
             }
         }
     }]
@@ -24,7 +24,7 @@ POLICY
 resource "aws_sns_topic_subscription" "transform_sns_event_subscriptions" {
   count = length(local.transform_sns_subscriptions)
 
-  topic_arn            = aws_sns_topic.transform_sns_topics[local.transform_sns_subscriptions[count.index].bucket_name].arn
+  topic_arn            = aws_sns_topic.transform_sns_topics[local.transform_sns_subscriptions[count.index].topic_name].arn
   protocol             = "sqs"
   raw_message_delivery = local.transform_sns_subscriptions[count.index].raw
   endpoint             = aws_sqs_queue.transform-lambda-sqs-queue[local.transform_sns_subscriptions[count.index].queue_name].arn

--- a/modules/cudl-data-processing/waf.tf
+++ b/modules/cudl-data-processing/waf.tf
@@ -40,6 +40,14 @@ resource "aws_wafv2_web_acl" "transcriptions" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
+          name = "NoUserAgent_HEADER"
+        }
       }
     }
 


### PR DESCRIPTION
This pull request adds in support for multiple different SNS per bucket.  This is because we have the need for many separate SNS attached to one bucket, with different suffix and prefixes, so that if a file needs to be processed in two or more different ways we have a way of doing that. 
Update includes: 
- Make the name of the topic "bucketname-prefix-suffix".  All special characters are removed, so there is the possibility of a duplicate sns but I think this is a meaningful name and unlikely to hit this case.
- Added another SNS to cover two separate lambda processes required by the cudl-ui file.
- Update image for tei-processing in dev
- Update WAF rule to allow specific requests without an agent or transcription requests from services were being denied. So no transcriptions were displayed. 