### PR TITLE
feat(sqs): Add delay_seconds argument

### DIFF
--- a/cudl-dev/terraform.tfvars
+++ b/cudl-dev/terraform.tfvars
@@ -212,6 +212,7 @@ transform-lambda-information = [
     "name"                     = "AWSLambda_CUDLPackageData_SOLR_Listener"
     "image_uri"                = "247242244017.dkr.ecr.eu-west-1.amazonaws.com/cudl-listener@sha256:2bdfa3e8bec89cece2790f9aa75207f1276cbb2b58821204c25161386b4912aa"
     "queue_name"               = "CUDLIndexQueue"
+    "queue_delay_seconds"      = 300
     "vpc_name"                 = "dev-cudlsolr-vpc"
     "subnet_names"             = ["dev-cudlsolr-subnet-private-b"]
     "security_group_names"     = ["dev-cudlsolr-vpc-endpoints", "dev-cudlsolr-alb"]

--- a/cudl-dev/variables.tf
+++ b/cudl-dev/variables.tf
@@ -86,6 +86,7 @@ variable "transform-lambda-information" {
     batch_size                 = optional(number)
     batch_window               = optional(number)
     maximum_concurrency        = optional(number)
+    queue_delay_seconds        = optional(number, 0)
     use_datadog_variables      = optional(bool, true)
     use_additional_variables   = optional(bool, false)
     use_enhancements_variables = optional(bool, false)

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -31,7 +31,9 @@ locals {
       for notification in var.transform-lambda-bucket-sqs-notifications : notification if notification.bucket_name == bucket
     ]
   }
-  transform_lambda_queues = toset([for lambda in var.transform-lambda-information : lambda.queue_name])
+  transform_lambda_queues = {for lambda in var.transform-lambda-information : lambda.queue_name => {
+    queue_delay_seconds = lambda.queue_delay_seconds
+  }}
 
   transform-lambda-buckets = {
     for bucket in toset([aws_s3_bucket.source-bucket, aws_s3_bucket.dest-bucket, aws_s3_bucket.enhancements-bucket]) :

--- a/modules/cudl-data-processing/sqs.tf
+++ b/modules/cudl-data-processing/sqs.tf
@@ -4,6 +4,7 @@ resource "aws_sqs_queue" "transform-lambda-sqs-queue" {
   name = substr("${var.environment}-${each.key}", 0, 64)
 
   visibility_timeout_seconds = 900
+  delay_seconds              = each.value.queue_delay_seconds
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -72,6 +72,7 @@ variable "transform-lambda-information" {
     batch_size                 = optional(number)
     batch_window               = optional(number)
     maximum_concurrency        = optional(number)
+    queue_delay_seconds        = optional(number, 0)
     use_datadog_variables      = optional(bool, true)
     use_additional_variables   = optional(bool, false)
     use_enhancements_variables = optional(bool, false)


### PR DESCRIPTION
- Add `delay_seconds` to `aws_sqs_queue.transform-lambda-sqs-queue`
- Add `queue_delay_seconds` property to `transform-lambda-information` variable in `cudl-data-processing` module, defaulting to 0
- Change `local.transform_lambda_queues` in `cudl-data-processing` module from set to map of maps
- Add `queue_delay_seconds` property to `AWSLambda_CUDLPackageData_SOLR_Listener` in `cudl-dev`