### PR TITLE
Cul cudl deployment patch services url

### DIFF
--- a/cul-cudl/templates/viewer/cudl-global.properties.ttfpl
+++ b/cul-cudl/templates/viewer/cudl-global.properties.ttfpl
@@ -36,7 +36,7 @@ dataUIThemeResources=${mount_path}/data/ui/
 # URLs for image and services servers.
 # Note after switch to IIIF (thumbnail data) we can remove IIIFImageServer
 imageServer=https://images.lib.cam.ac.uk/
-SERVICES=https://first-cudl-ecs-services.cul-cudl.net/
+services=https://first-cudl-ecs-services.cul-cudl.net/
 IIIFImageServer=https://images.lib.cam.ac.uk/iiif/
 
 # Email address to send the feedback form to.

--- a/cul-cudl/templates/viewer/cudl-global.properties.ttfpl
+++ b/cul-cudl/templates/viewer/cudl-global.properties.ttfpl
@@ -36,7 +36,7 @@ dataUIThemeResources=${mount_path}/data/ui/
 # URLs for image and services servers.
 # Note after switch to IIIF (thumbnail data) we can remove IIIFImageServer
 imageServer=https://images.lib.cam.ac.uk/
-services=http://cudl-services/
+SERVICES=https://first-cudl-ecs-services.cul-cudl.net/
 IIIFImageServer=https://images.lib.cam.ac.uk/iiif/
 
 # Email address to send the feedback form to.


### PR DESCRIPTION
There's probably a better way of doing this, but at the moment the viewer is still having issues actually getting the transcriptions because it's looking at e.g. http://cudl-services/v1/transcription/tei/diplomatic/internal/MS-ADD-03958/i111

You can see this on the network traffic for the page: 
https://first-cudl-ecs-cudl-viewer.cul-cudl.net/view/MS-ADD-03958/111

This should allow it to find transcriptions. 

This will also need updating on other environments. 