### PR TITLE
Disable IP restriction on services, and update the terraform version

### DIFF
--- a/cul-cudl-production/cudl_services_waf.tf
+++ b/cul-cudl-production/cudl_services_waf.tf
@@ -1,0 +1,96 @@
+resource "aws_wafv2_web_acl" "cudl_services" {
+  name        = "${module.cudl_services.name_prefix}-waf-web-acl"
+  provider    = aws.us-east-1
+  description = "Managed by Terraform"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${module.cudl_services.name_prefix}-waf-web-acl-no-rule"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 0
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          name = "SizeRestrictions_QUERYSTRING"
+          action_to_use {
+            allow {}
+          }
+        }
+
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+          action_to_use {
+            allow {}
+          }
+        }
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+}

--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -131,7 +131,7 @@ module "cudl_services" {
   asg_security_group_id                     = module.base_architecture.asg_security_group_id
   alb_security_group_id                     = module.base_architecture.alb_security_group_id
   cloudwatch_log_group_arn                  = module.base_architecture.cloudwatch_log_group_arn
-  cloudfront_waf_acl_arn                    = module.base_architecture.waf_acl_arn
+  cloudfront_waf_acl_arn                    = aws_wafv2_web_acl.cudl_services.arn # custom WAF ACL for Services
   cloudfront_allowed_methods                = var.cudl_services_allowed_methods
   acm_create_certificate                    = false
   acm_certificate_arn                       = var.acm_certificate_arn

--- a/cul-cudl-production/terraform.tf
+++ b/cul-cudl-production/terraform.tf
@@ -21,5 +21,5 @@ terraform {
     region         = "eu-west-1"
   }
 
-  required_version = "~> 1.7.5"
+  required_version = "~> 1.9.7"
 }

--- a/cul-cudl-staging/cudl_services_waf.tf
+++ b/cul-cudl-staging/cudl_services_waf.tf
@@ -1,0 +1,96 @@
+resource "aws_wafv2_web_acl" "cudl_services" {
+  name        = "${module.cudl_services.name_prefix}-waf-web-acl"
+  provider    = aws.us-east-1
+  description = "Managed by Terraform"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${module.cudl_services.name_prefix}-waf-web-acl-no-rule"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 0
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          name = "SizeRestrictions_QUERYSTRING"
+          action_to_use {
+            allow {}
+          }
+        }
+
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+          action_to_use {
+            allow {}
+          }
+        }
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+}

--- a/cul-cudl-staging/main.tf
+++ b/cul-cudl-staging/main.tf
@@ -182,7 +182,7 @@ module "cudl_services" {
   asg_security_group_id                     = module.base_architecture.asg_security_group_id
   alb_security_group_id                     = module.base_architecture.alb_security_group_id
   cloudwatch_log_group_arn                  = module.base_architecture.cloudwatch_log_group_arn
-  cloudfront_waf_acl_arn                    = module.base_architecture.waf_acl_arn
+  cloudfront_waf_acl_arn                    = aws_wafv2_web_acl.cudl_services.arn # custom WAF ACL for Services
   cloudfront_allowed_methods                = var.cudl_services_allowed_methods
   acm_create_certificate                    = false
   acm_certificate_arn                       = var.acm_certificate_arn

--- a/cul-cudl-staging/terraform.tf
+++ b/cul-cudl-staging/terraform.tf
@@ -21,5 +21,5 @@ terraform {
     region         = "eu-west-1"
   }
 
-  required_version = "~> 1.7.5"
+  required_version = "~> 1.9.7"
 }


### PR DESCRIPTION
Following changes: 

- Add a custom WAF for staging and production to disable IP restriction. This should be the same value as viewer. This was causing Transcriptions to be only visible within the library VPN, as they come through services.
- Update to Terraform version 1.9.7