### PR TITLE
fix(cul-cudl-production): Update capacity for SOLR

### DIFF
--- a/cul-cudl-production/solr_container_def.tf
+++ b/cul-cudl-production/solr_container_def.tf
@@ -3,10 +3,12 @@ locals {
   solr_container_name_api  = join("-", [var.solr_container_name_api, var.cluster_name_suffix])
   solr_container_defs = [
     {
-      name           = local.solr_container_name_solr,
-      systemControls = [],
-      image          = data.aws_ecr_image.solr["cudl/solr"].image_uri,
-      cpu            = 0,
+      name              = local.solr_container_name_solr,
+      systemControls    = [],
+      image             = data.aws_ecr_image.solr["cudl/solr"].image_uri,
+      cpu               = var.solr_ecs_task_def_cpu - var.solr_api_ecs_container_def_cpu,
+      memory            = var.solr_ecs_task_def_memory - var.solr_api_ecs_container_def_memory_reservation
+      memoryReservation = var.solr_ecs_task_def_memory - var.solr_api_ecs_container_def_memory
       portMappings = [
         {
           containerPort = var.solr_application_port,
@@ -22,6 +24,10 @@ locals {
         {
           name  = "SOLR_JAVA_MEM",
           value = "-Xms1g -Xmx1g"
+        },
+        {
+          name  = "SOLR_HEAP",
+          value = "1024m"
         }
       ],
       environmentFiles = [],
@@ -59,9 +65,9 @@ locals {
       name              = local.solr_container_name_api,
       systemControls    = [],
       image             = data.aws_ecr_image.solr["cudl/solr-api"].image_uri,
-      cpu               = 1024,
-      memory            = 1024,
-      memoryReservation = 1024,
+      cpu               = var.solr_api_ecs_container_def_cpu,
+      memory            = var.solr_api_ecs_container_def_memory,
+      memoryReservation = var.solr_api_ecs_container_def_memory_reservation,
       portMappings = [
         {
           containerPort = var.solr_target_group_port,

--- a/cul-cudl-production/terraform.tfvars
+++ b/cul-cudl-production/terraform.tfvars
@@ -161,14 +161,17 @@ solr_ecr_repositories = {
   "cudl/solr-api" = "sha256:2892d0023e4014ad569121551b8b959cd32f5c6658e671973bcfc783836bf65f",
   "cudl/solr"     = "sha256:8dfcce2322e381d92bc02d19710afa8ec15e5a8f6c1efa1edddf550527c51fdb"
 }
-solr_ecs_task_def_volumes     = { "solr-volume" = "/var/solr" }
-solr_container_name_api       = "solr-api"
-solr_container_name_solr      = "solr"
-solr_health_check_status_code = "404"
-solr_allowed_methods          = ["HEAD", "GET", "OPTIONS"]
-solr_ecs_task_def_cpu         = 1536
-solr_ecs_task_def_memory      = 1638
-solr_use_service_discovery    = true
+solr_ecs_task_def_volumes                     = { "solr-volume" = "/var/solr" }
+solr_container_name_api                       = "solr-api"
+solr_container_name_solr                      = "solr"
+solr_health_check_status_code                 = "404"
+solr_allowed_methods                          = ["HEAD", "GET", "OPTIONS"]
+solr_ecs_task_def_cpu                         = 2048
+solr_ecs_task_def_memory                      = 1942
+solr_api_ecs_container_def_cpu                = 256
+solr_api_ecs_container_def_memory             = 256
+solr_api_ecs_container_def_memory_reservation = 128
+solr_use_service_discovery                    = true
 
 cudl_services_name_suffix       = "cudl-services"
 cudl_services_domain_name       = "services"

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -276,6 +276,21 @@ variable "solr_ecs_task_def_memory" {
   description = "Amount (in MiB) of memory used by the SOLR tasks"
 }
 
+variable "solr_api_ecs_container_def_cpu" {
+  type        = number
+  description = "Amount of CPU reserved to the SOLR API container"
+}
+
+variable "solr_api_ecs_container_def_memory" {
+  type        = number
+  description = "Maximum amount (in MiB) of memory used by the SOLR API container"
+}
+
+variable "solr_api_ecs_container_def_memory_reservation" {
+  type        = number
+  description = "Amount (in MiB) of memory reserved by the SOLR API container"
+}
+
 variable "solr_use_service_discovery" {
   type        = bool
   description = "Whether SOLR should use Service Discovery"


### PR DESCRIPTION
- Add `SOLR_HEAP` environment variable to solr container
- Update values for cpu, memory and memory reservation for solr and solr-api containers
- Increase total cpu and memory allocated to solr ECS task, as opposed to individual containers
- Add new variables `solr_api_ecs_container_def_cpu`, `solr_api_ecs_container_def_memory` and `solr_api_ecs_container_def_memory_reservation`