### PR TITLE
Add custom WAF for Staging Content Loader

### DIFF
--- a/cul-cudl-production/cudl_services_container_def.tf
+++ b/cul-cudl-production/cudl_services_container_def.tf
@@ -5,7 +5,7 @@ locals {
       name              = local.cudl_services_container_name,
       image             = data.aws_ecr_image.cudl_services["cudl/services"].image_uri,
       cpu               = 0,
-      memoryReservation = 512,
+      memoryReservation = data.aws_ec2_instance_type.asg.memory_size - 512,
       portMappings = [
         {
           containerPort = var.cudl_services_container_port,

--- a/cul-cudl-production/cudl_viewer_container_def.tf
+++ b/cul-cudl-production/cudl_viewer_container_def.tf
@@ -7,8 +7,8 @@ locals {
       name              = local.cudl_viewer_container_name,
       image             = data.aws_ecr_image.cudl_viewer["cudl/viewer"].image_uri,
       cpu               = 2048,
-      memoryReservation = 1024,
-      memory            = var.cudl_viewer_ecs_task_def_memory,
+      memoryReservation = data.aws_ec2_instance_type.asg.memory_size - 1024,
+      memory            = data.aws_ec2_instance_type.asg.memory_size - 512,
       portMappings = [
         {
           containerPort = var.cudl_viewer_container_port,

--- a/cul-cudl-production/data.tf
+++ b/cul-cudl-production/data.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_ec2_instance_type" "asg" {
+  instance_type = var.ec2_instance_type
+}
+
 data "aws_ecr_image" "solr" {
   for_each        = var.solr_ecr_repositories
   repository_name = each.key

--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -71,7 +71,7 @@ module "solr" {
   ecs_task_def_container_definitions             = jsonencode(local.solr_container_defs)
   ecs_task_def_volumes                           = keys(var.solr_ecs_task_def_volumes)
   ecs_task_def_cpu                               = var.solr_ecs_task_def_cpu
-  ecs_task_def_memory                            = var.solr_ecs_task_def_memory
+  ecs_task_def_memory                            = data.aws_ec2_instance_type.asg.memory_size - 512
   ecs_service_container_name                     = local.solr_container_name_api
   ecs_service_container_port                     = var.solr_target_group_port
   ecs_service_capacity_provider_name             = module.base_architecture.ecs_capacity_provider_name
@@ -114,6 +114,7 @@ module "cudl_services" {
   ecr_repositories_exist                    = true
   s3_task_execution_bucket                  = module.base_architecture.s3_bucket
   ecs_task_def_container_definitions        = jsonencode(local.cudl_services_container_defs)
+  ecs_task_def_memory                       = data.aws_ec2_instance_type.asg.memory_size - 512
   ecs_service_container_name                = local.cudl_services_container_name
   ecs_service_container_port                = var.cudl_services_container_port
   ecs_service_capacity_provider_name        = module.base_architecture.ecs_capacity_provider_name
@@ -155,7 +156,7 @@ module "cudl_viewer" {
   ecs_network_mode                          = "awsvpc"
   ecs_task_def_container_definitions        = jsonencode(local.cudl_viewer_container_defs)
   ecs_task_def_volumes                      = keys(var.cudl_viewer_ecs_task_def_volumes)
-  ecs_task_def_memory                       = var.cudl_viewer_ecs_task_def_memory
+  ecs_task_def_memory                       = data.aws_ec2_instance_type.asg.memory_size - 512
   ecs_service_container_name                = local.cudl_viewer_container_name
   ecs_service_container_port                = var.cudl_viewer_container_port
   ecs_service_capacity_provider_name        = module.base_architecture.ecs_capacity_provider_name

--- a/cul-cudl-production/terraform.tfvars
+++ b/cul-cudl-production/terraform.tfvars
@@ -143,6 +143,7 @@ registered_domain_name         = "cudl.lib.cam.ac.uk."
 asg_desired_capacity           = 3 # n = number of tasks
 asg_max_size                   = 4 # n + 1
 asg_allow_all_egress           = true
+ec2_instance_type              = "t3.large"
 route53_zone_id_existing       = "Z03809063VDGJ8MKPHFRV"
 route53_zone_force_destroy     = true
 acm_certificate_arn            = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
@@ -167,7 +168,6 @@ solr_container_name_solr      = "solr"
 solr_health_check_status_code = "404"
 solr_allowed_methods          = ["HEAD", "GET", "OPTIONS"]
 solr_ecs_task_def_cpu         = 1536
-solr_ecs_task_def_memory      = 1638
 solr_use_service_discovery    = true
 
 cudl_services_name_suffix       = "cudl-services"
@@ -192,4 +192,3 @@ cudl_viewer_allowed_methods                 = ["HEAD", "DELETE", "POST", "GET", 
 cudl_viewer_ecs_task_def_volumes            = { "cudl-viewer" = "/srv/cudl-viewer/cudl-data" }
 cudl_viewer_datasync_task_s3_to_efs_pattern = "/json/*|/pages/*|/cudl.dl-dataset.json|/cudl.ui.json5|/collections/*|/ui/*"
 cudl_viewer_alternative_domain_names        = ["cudl.lib.cam.ac.uk"]
-cudl_viewer_ecs_task_def_memory             = 1920

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -147,7 +147,6 @@ variable "cluster_name_suffix" {
 variable "ec2_instance_type" {
   type        = string
   description = "EC2 Instance type used by EC2 Instances"
-  default     = "t3.small"
 }
 
 variable "asg_max_size" {
@@ -271,11 +270,6 @@ variable "solr_ecs_task_def_cpu" {
   description = "Number of cpu units used by the SOLR tasks"
 }
 
-variable "solr_ecs_task_def_memory" {
-  type        = number
-  description = "Amount (in MiB) of memory used by the SOLR tasks"
-}
-
 variable "solr_use_service_discovery" {
   type        = bool
   description = "Whether SOLR should use Service Discovery"
@@ -376,9 +370,4 @@ variable "cudl_viewer_datasync_task_s3_to_efs_pattern" {
 variable "cudl_viewer_alternative_domain_names" {
   type        = list(string)
   description = "List of additional host headers for CUDL Viewer"
-}
-
-variable "cudl_viewer_ecs_task_def_memory" {
-  type        = number
-  description = "Amount (in MiB) of memory used by the CUDL Viewer tasks"
 }

--- a/cul-cudl-staging/content_loader_waf.tf
+++ b/cul-cudl-staging/content_loader_waf.tf
@@ -1,0 +1,92 @@
+resource "aws_wafv2_web_acl" "content_loader" {
+  name        = "${module.content_loader.name_prefix}-waf-web-acl"
+  provider    = aws.us-east-1
+  description = "Managed by Terraform"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${module.content_loader.name_prefix}-waf-web-acl-no-rule"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 0
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        dynamic "rule_action_override" {
+          for_each = toset(var.content_loader_waf_common_ruleset_override_actions)
+          content {
+            name = rule_action_override.key
+            action_to_use {
+              allow {}
+            }
+          }
+        }
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+}

--- a/cul-cudl-staging/main.tf
+++ b/cul-cudl-staging/main.tf
@@ -89,7 +89,7 @@ module "content_loader" {
   asg_security_group_id      = module.base_architecture.asg_security_group_id
   alb_security_group_id      = module.base_architecture.alb_security_group_id
   cloudwatch_log_group_arn   = module.base_architecture.cloudwatch_log_group_arn
-  cloudfront_waf_acl_arn     = module.base_architecture.waf_acl_arn
+  cloudfront_waf_acl_arn     = aws_wafv2_web_acl.content_loader.arn # custom WAF ACL for Content Loader
   cloudfront_allowed_methods = var.content_loader_allowed_methods
   iam_task_additional_policies = {
     staging_releases    = aws_iam_policy.staging_cudl_data_releases.arn,

--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -311,12 +311,13 @@ content_loader_ecr_repositories = {
   "cudl/content-loader-db" = "sha256:2f95f1e174623af80ddae2409771a07c0d1c71d7b83e4f42899b608810f70cab",
   "cudl/content-loader-ui" = "sha256:293c28a8f0f09456afae9af23efa65ea4a820410c5e14aad761950cd8c4e43d5"
 }
-content_loader_ecs_task_def_volumes       = { "dl-loader-db" = "/var/lib/postgresql/data" }
-content_loader_container_name_ui          = "dl-loader-ui"
-content_loader_container_name_db          = "dl-loader-db"
-content_loader_health_check_status_code   = "401"
-content_loader_allowed_methods            = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
-content_loader_releases_bucket_production = "production-cul-cudl-data-releases"
+content_loader_ecs_task_def_volumes                = { "dl-loader-db" = "/var/lib/postgresql/data" }
+content_loader_container_name_ui                   = "dl-loader-ui"
+content_loader_container_name_db                   = "dl-loader-db"
+content_loader_health_check_status_code            = "401"
+content_loader_allowed_methods                     = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+content_loader_releases_bucket_production          = "production-cul-cudl-data-releases"
+content_loader_waf_common_ruleset_override_actions = ["SizeRestrictions_QUERYSTRING", "SizeRestrictions_BODY", "GenericLFI_BODY", "CrossSiteScripting_BODY"]
 
 # SOLR Worload
 solr_name_suffix       = "solr"

--- a/cul-cudl-staging/variables.tf
+++ b/cul-cudl-staging/variables.tf
@@ -281,6 +281,11 @@ variable "content_loader_releases_bucket_production" {
   description = "Name of the production releases bucket for content loader deployments"
 }
 
+variable "content_loader_waf_common_ruleset_override_actions" {
+  type        = list(string)
+  description = "List of rules in the AWS WAF Core rule set (CRS) managed rule group to override"
+}
+
 variable "solr_name_suffix" {
   type        = string
   description = "Suffix to add to SOLR resource names"


### PR DESCRIPTION
- Add custom WAF for Staging Content Loader
- Override additional WAF rules for Staging Content Loader allowing `GenericLFI_BODY` and `CrossSiteScripting_BODY` rules in addition to `SizeRestrictions_QUERYSTRING` and `SizeRestrictions_BODY` on generic WAF
- Update EC2 instance type in Production to `t3.large`