### PR TITLE
feat(cul-cudl-staging): Increase content loader response timeout

### DIFF
--- a/cul-cudl-staging/main.tf
+++ b/cul-cudl-staging/main.tf
@@ -78,19 +78,20 @@ module "content_loader" {
       releases_bucket_production = var.content_loader_releases_bucket_production
     })
   }
-  vpc_id                     = module.base_architecture.vpc_id
-  vpc_subnet_ids             = module.base_architecture.vpc_private_subnet_ids
-  alb_arn                    = module.base_architecture.alb_arn
-  alb_dns_name               = module.base_architecture.alb_dns_name
-  alb_listener_arn           = module.base_architecture.alb_https_listener_arn
-  ecs_cluster_arn            = module.base_architecture.ecs_cluster_arn
-  route53_zone_id            = module.base_architecture.route53_public_hosted_zone
-  asg_name                   = module.base_architecture.asg_name
-  asg_security_group_id      = module.base_architecture.asg_security_group_id
-  alb_security_group_id      = module.base_architecture.alb_security_group_id
-  cloudwatch_log_group_arn   = module.base_architecture.cloudwatch_log_group_arn
-  cloudfront_waf_acl_arn     = aws_wafv2_web_acl.content_loader.arn # custom WAF ACL for Content Loader
-  cloudfront_allowed_methods = var.content_loader_allowed_methods
+  vpc_id                         = module.base_architecture.vpc_id
+  vpc_subnet_ids                 = module.base_architecture.vpc_private_subnet_ids
+  alb_arn                        = module.base_architecture.alb_arn
+  alb_dns_name                   = module.base_architecture.alb_dns_name
+  alb_listener_arn               = module.base_architecture.alb_https_listener_arn
+  ecs_cluster_arn                = module.base_architecture.ecs_cluster_arn
+  route53_zone_id                = module.base_architecture.route53_public_hosted_zone
+  asg_name                       = module.base_architecture.asg_name
+  asg_security_group_id          = module.base_architecture.asg_security_group_id
+  alb_security_group_id          = module.base_architecture.alb_security_group_id
+  cloudwatch_log_group_arn       = module.base_architecture.cloudwatch_log_group_arn
+  cloudfront_waf_acl_arn         = aws_wafv2_web_acl.content_loader.arn # custom WAF ACL for Content Loader
+  cloudfront_origin_read_timeout = var.content_loader_cloudfront_origin_read_timeout
+  cloudfront_allowed_methods     = var.content_loader_allowed_methods
   iam_task_additional_policies = {
     staging_releases    = aws_iam_policy.staging_cudl_data_releases.arn,
     staging_source      = aws_iam_policy.staging_cudl_data_source.arn,

--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -318,6 +318,7 @@ content_loader_health_check_status_code            = "401"
 content_loader_allowed_methods                     = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
 content_loader_releases_bucket_production          = "production-cul-cudl-data-releases"
 content_loader_waf_common_ruleset_override_actions = ["SizeRestrictions_QUERYSTRING", "SizeRestrictions_BODY", "GenericLFI_BODY", "CrossSiteScripting_BODY"]
+content_loader_cloudfront_origin_read_timeout      = 180
 
 # SOLR Worload
 solr_name_suffix       = "solr"

--- a/cul-cudl-staging/variables.tf
+++ b/cul-cudl-staging/variables.tf
@@ -286,6 +286,11 @@ variable "content_loader_waf_common_ruleset_override_actions" {
   description = "List of rules in the AWS WAF Core rule set (CRS) managed rule group to override"
 }
 
+variable "content_loader_cloudfront_origin_read_timeout" {
+  type        = number
+  description = "CloudFront origin response timeout for Content Loader"
+}
+
 variable "solr_name_suffix" {
   type        = string
   description = "Suffix to add to SOLR resource names"


### PR DESCRIPTION
- Set `cloudfront_origin_read_timeout` argument in `content_loader` module
- Add variable `content_loader_cloudfront_origin_read_timeout`
- Set `content_loader_cloudfront_origin_read_timeout` value to 180