### PR TITLE
Adjust system resources for SOLR deployment in `cul-cudl-production` environment

### DIFF
--- a/cul-cudl-production/locals.tf
+++ b/cul-cudl-production/locals.tf
@@ -19,5 +19,6 @@ locals {
     AWS_CUDL_DATA_SOURCE_BUCKET = "${local.environment}-cudl-data-source"
     AWS_OUTPUT_BUCKET           = "${local.environment}-cudl-data-source"
   }
-  smtp_port = tonumber(data.aws_ssm_parameter.cudl_viewer_smtp_port.value)
+  smtp_port                = tonumber(data.aws_ssm_parameter.cudl_viewer_smtp_port.value)
+  solr_ecs_task_def_memory = data.aws_ec2_instance_type.asg.memory_size - 512
 }

--- a/cul-cudl-production/locals.tf
+++ b/cul-cudl-production/locals.tf
@@ -20,5 +20,5 @@ locals {
     AWS_OUTPUT_BUCKET           = "${local.environment}-cudl-data-source"
   }
   smtp_port                = tonumber(data.aws_ssm_parameter.cudl_viewer_smtp_port.value)
-  solr_ecs_task_def_memory = data.aws_ec2_instance_type.asg.memory_size - 512
+  solr_ecs_task_def_memory = data.aws_ec2_instance_type.asg.memory_size - 768
 }

--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -72,7 +72,7 @@ module "solr" {
   ecs_task_def_container_definitions             = jsonencode(local.solr_container_defs)
   ecs_task_def_volumes                           = keys(var.solr_ecs_task_def_volumes)
   ecs_task_def_cpu                               = var.solr_ecs_task_def_cpu
-  ecs_task_def_memory                            = data.aws_ec2_instance_type.asg.memory_size - 512
+  ecs_task_def_memory                            = local.solr_ecs_task_def_memory
   ecs_service_container_name                     = local.solr_container_name_api
   ecs_service_container_port                     = var.solr_target_group_port
   ecs_service_capacity_provider_name             = module.base_architecture.ecs_capacity_provider_name

--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -1,8 +1,9 @@
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.0.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.1.0"
 
   name_prefix                    = local.base_name_prefix
   ec2_instance_type              = var.ec2_instance_type
+  ec2_additional_userdata        = var.ec2_additional_userdata
   route53_zone_domain_name       = var.registered_domain_name
   route53_zone_id_existing       = var.route53_zone_id_existing
   route53_zone_force_destroy     = var.route53_zone_force_destroy

--- a/cul-cudl-production/solr_container_def.tf
+++ b/cul-cudl-production/solr_container_def.tf
@@ -3,10 +3,12 @@ locals {
   solr_container_name_api  = join("-", [var.solr_container_name_api, var.cluster_name_suffix])
   solr_container_defs = [
     {
-      name           = local.solr_container_name_solr,
-      systemControls = [],
-      image          = data.aws_ecr_image.solr["cudl/solr"].image_uri,
-      cpu            = 0,
+      name              = local.solr_container_name_solr,
+      systemControls    = [],
+      image             = data.aws_ecr_image.solr["cudl/solr"].image_uri,
+      cpu               = floor((var.solr_ecs_task_def_cpu / 3) * 2),
+      memory            = local.solr_ecs_task_def_memory - 512
+      memoryReservation = local.solr_ecs_task_def_memory - 1024
       portMappings = [
         {
           containerPort = var.solr_application_port,
@@ -20,8 +22,8 @@ locals {
       entryPoint = [],
       environment = [
         {
-          name  = "SOLR_JAVA_MEM",
-          value = "-Xms1g -Xmx1g"
+          name  = "SOLR_HEAP",
+          value = format("%sm", floor(local.solr_ecs_task_def_memory / 2))
         }
       ],
       environmentFiles = [],
@@ -59,9 +61,9 @@ locals {
       name              = local.solr_container_name_api,
       systemControls    = [],
       image             = data.aws_ecr_image.solr["cudl/solr-api"].image_uri,
-      cpu               = 1024,
+      cpu               = floor(var.solr_ecs_task_def_cpu / 3),
       memory            = 1024,
-      memoryReservation = 1024,
+      memoryReservation = 512,
       portMappings = [
         {
           containerPort = var.solr_target_group_port,
@@ -87,9 +89,9 @@ locals {
           value = tostring(var.solr_target_group_port)
         },
         {
-          name  = "EXTRA_VAR"
-          value = "25"
-        }
+          name  = "NUM_WORKERS"
+          value = "4"
+        },
       ],
       environmentFiles = [],
       mountPoints      = [],

--- a/cul-cudl-production/solr_container_def.tf
+++ b/cul-cudl-production/solr_container_def.tf
@@ -90,7 +90,7 @@ locals {
         },
         {
           name  = "NUM_WORKERS"
-          value = "4"
+          value = "3"
         },
       ],
       environmentFiles = [],

--- a/cul-cudl-production/terraform.tfvars
+++ b/cul-cudl-production/terraform.tfvars
@@ -144,6 +144,10 @@ asg_desired_capacity           = 3 # n = number of tasks
 asg_max_size                   = 4 # n + 1
 asg_allow_all_egress           = true
 ec2_instance_type              = "t3.large"
+ec2_additional_userdata        = <<-EOF
+echo 1 > /proc/sys/vm/swappiness
+echo ECS_RESERVED_MEMORY=256 >> /etc/ecs/ecs.config
+EOF
 route53_zone_id_existing       = "Z03809063VDGJ8MKPHFRV"
 route53_zone_force_destroy     = true
 acm_certificate_arn            = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
@@ -159,7 +163,7 @@ solr_domain_name       = "search"
 solr_application_port  = 8983
 solr_target_group_port = 8081
 solr_ecr_repositories = {
-  "cudl/solr-api" = "sha256:2892d0023e4014ad569121551b8b959cd32f5c6658e671973bcfc783836bf65f",
+  "cudl/solr-api" = "sha256:f5663ef09aa01c90a92057d161c4a3c83bb851137eb8b6dc1228d2727a130810",
   "cudl/solr"     = "sha256:8dfcce2322e381d92bc02d19710afa8ec15e5a8f6c1efa1edddf550527c51fdb"
 }
 solr_ecs_task_def_volumes     = { "solr-volume" = "/var/solr" }
@@ -167,7 +171,7 @@ solr_container_name_api       = "solr-api"
 solr_container_name_solr      = "solr"
 solr_health_check_status_code = "404"
 solr_allowed_methods          = ["HEAD", "GET", "OPTIONS"]
-solr_ecs_task_def_cpu         = 1536
+solr_ecs_task_def_cpu         = 2048
 solr_use_service_discovery    = true
 
 cudl_services_name_suffix       = "cudl-services"

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -149,6 +149,11 @@ variable "ec2_instance_type" {
   description = "EC2 Instance type used by EC2 Instances"
 }
 
+variable "ec2_additional_userdata" {
+  type        = string
+  description = "Additional userdata to append to EC2 instances"
+}
+
 variable "asg_max_size" {
   type        = number
   description = "Maximum number of instances in the Autoscaling Group"


### PR DESCRIPTION
- Change version of `base_architecture` module to `v2.1.0`
- Add `ec2_additional_userdata` argument to `base_architecture` module
- Update `cpu`, `memory` and `memoryReservation` values for solr and solr-api containers
- Replace `SOLR_JAVA_MEM` environment variable in solr container with `SOLR_HEAP`
- Update version of solr-api image
- Add `NUM_WORKERS` environment variable to solr-api container
- Update value of `solr_ecs_task_def_cpu` to 2048
- Add local variable `solr_ecs_task_def_memory`