### PR TITLE
Adjust values for solr module in cudl-sandbox

### DIFF
--- a/cudl-sandbox/data.tf
+++ b/cudl-sandbox/data.tf
@@ -1,27 +1,31 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_ec2_instance_type" "asg" {
+  instance_type = var.ec2_instance_type
+}
+
 data "aws_ecr_image" "content_loader" {
-  for_each        = toset(var.content_loader_ecr_repository_names)
+  for_each        = var.content_loader_ecr_repositories
   repository_name = each.key
-  image_tag       = "latest"
+  image_digest    = each.value
 }
 
 data "aws_ecr_image" "solr" {
-  for_each        = toset(var.solr_ecr_repository_names)
+  for_each        = var.solr_ecr_repositories
   repository_name = each.key
-  image_tag       = "latest"
+  image_digest    = each.value
 }
 
 data "aws_ecr_image" "cudl_services" {
-  for_each        = toset(var.cudl_services_ecr_repository_names)
+  for_each        = var.cudl_services_ecr_repositories
   repository_name = each.key
-  image_tag       = "ae4e"
+  image_digest    = each.value
 }
 
 data "aws_ecr_image" "cudl_viewer" {
-  for_each        = toset(var.cudl_viewer_ecr_repository_names)
+  for_each        = var.cudl_viewer_ecr_repositories
   repository_name = each.key
-  image_tag       = "3cc1224"
+  image_digest    = each.value
 }
 
 data "aws_ssm_parameter" "cudl_viewer_cloudfront_username" {

--- a/cudl-sandbox/locals.tf
+++ b/cudl-sandbox/locals.tf
@@ -20,4 +20,5 @@ locals {
     AWS_CUDL_DATA_SOURCE_BUCKET = "${local.environment}-cudl-data-source"
     AWS_OUTPUT_BUCKET           = "${local.environment}-cudl-data-source"
   }
+  solr_ecs_task_def_memory = data.aws_ec2_instance_type.asg.memory_size - 768
 }

--- a/cudl-sandbox/main.tf
+++ b/cudl-sandbox/main.tf
@@ -31,10 +31,11 @@ module "cudl-data-processing" {
 }
 
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.0.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.1.0"
 
   name_prefix                    = local.base_name_prefix
   ec2_instance_type              = var.ec2_instance_type
+  ec2_additional_userdata        = var.ec2_additional_userdata
   route53_zone_domain_name       = var.registered_domain_name
   route53_zone_id_existing       = var.route53_zone_id_existing
   route53_zone_force_destroy     = var.route53_zone_force_destroy
@@ -57,7 +58,7 @@ module "content_loader" {
   domain_name                               = join(".", [join("-", compact([var.environment, var.cluster_name_suffix, var.content_loader_domain_name])), var.registered_domain_name])
   alb_target_group_port                     = var.content_loader_target_group_port
   alb_target_group_health_check_status_code = var.content_loader_health_check_status_code
-  ecr_repository_names                      = var.content_loader_ecr_repository_names
+  ecr_repository_names                      = keys(var.content_loader_ecr_repositories)
   ecr_repositories_exist                    = true
   s3_task_buckets                           = [module.cudl-data-processing.source_bucket]
   s3_task_execution_bucket                  = module.base_architecture.s3_bucket
@@ -105,7 +106,7 @@ module "solr" {
   alb_target_group_deregistration_delay          = 60
   alb_target_group_health_check_interval         = 30
   alb_target_group_health_check_timeout          = 10
-  ecr_repository_names                           = var.solr_ecr_repository_names
+  ecr_repository_names                           = keys(var.solr_ecr_repositories)
   ecr_repositories_exist                         = true
   s3_task_buckets                                = [module.cudl-data-processing.destination_bucket]
   s3_task_execution_bucket                       = module.base_architecture.s3_bucket
@@ -113,7 +114,7 @@ module "solr" {
   ecs_task_def_container_definitions             = jsonencode(local.solr_container_defs)
   ecs_task_def_volumes                           = keys(var.solr_ecs_task_def_volumes)
   ecs_task_def_cpu                               = var.solr_ecs_task_def_cpu
-  ecs_task_def_memory                            = var.solr_ecs_task_def_memory
+  ecs_task_def_memory                            = local.solr_ecs_task_def_memory
   ecs_service_container_name                     = local.solr_container_name_api
   ecs_service_container_port                     = var.solr_target_group_port
   ecs_service_capacity_provider_name             = module.base_architecture.ecs_capacity_provider_name
@@ -158,7 +159,7 @@ module "cudl_services" {
   domain_name                               = join(".", [join("-", compact([var.environment, var.cluster_name_suffix, var.cudl_services_domain_name])), var.registered_domain_name])
   alb_target_group_port                     = var.cudl_services_target_group_port
   alb_target_group_health_check_status_code = var.cudl_services_health_check_status_code
-  ecr_repository_names                      = var.cudl_services_ecr_repository_names
+  ecr_repository_names                      = keys(var.cudl_services_ecr_repositories)
   ecr_repositories_exist                    = true
   s3_task_execution_bucket                  = module.base_architecture.s3_bucket
   ecs_task_def_container_definitions        = jsonencode(local.cudl_services_container_defs)
@@ -193,7 +194,7 @@ module "cudl_viewer" {
   domain_name                               = join(".", [join("-", compact([var.environment, var.cluster_name_suffix, var.cudl_viewer_domain_name])), var.registered_domain_name])
   alb_target_group_port                     = var.cudl_viewer_container_port
   alb_target_group_health_check_status_code = var.cudl_viewer_health_check_status_code
-  ecr_repository_names                      = var.cudl_viewer_ecr_repository_names
+  ecr_repository_names                      = keys(var.cudl_viewer_ecr_repositories)
   ecr_repositories_exist                    = true
   s3_task_execution_bucket                  = module.base_architecture.s3_bucket
   ecs_network_mode                          = "awsvpc"

--- a/cudl-sandbox/solr_container_def.tf
+++ b/cudl-sandbox/solr_container_def.tf
@@ -3,10 +3,12 @@ locals {
   solr_container_name_api  = join("-", [var.solr_container_name_api, var.cluster_name_suffix])
   solr_container_defs = [
     {
-      name           = local.solr_container_name_solr,
-      systemControls = [],
-      image          = data.aws_ecr_image.solr["cudl-solr"].image_uri,
-      cpu            = 0,
+      name              = local.solr_container_name_solr,
+      systemControls    = [],
+      image             = data.aws_ecr_image.solr["cudl-solr"].image_uri,
+      cpu               = floor((var.solr_ecs_task_def_cpu / 3) * 2),
+      memory            = local.solr_ecs_task_def_memory - 512
+      memoryReservation = local.solr_ecs_task_def_memory - 1024
       portMappings = [
         {
           containerPort = var.solr_application_port,
@@ -20,8 +22,8 @@ locals {
       entryPoint = [],
       environment = [
         {
-          name  = "SOLR_JAVA_MEM",
-          value = "-Xms1g -Xmx1g"
+          name  = "SOLR_HEAP",
+          value = format("%sm", floor(local.solr_ecs_task_def_memory / 2))
         }
       ],
       environmentFiles = [],
@@ -46,20 +48,22 @@ locals {
       },
       privileged = true,
       logConfiguration = {
-        logDriver = "syslog",
+        logDriver = "awslogs"
         options = {
-          syslog-address = "tcp://fluentd.sandbox-fluentd:5140"
-          tag            = local.solr_container_name_solr
-        }
+          awslogs-group         = module.base_architecture.cloudwatch_log_group_name,
+          awslogs-region        = var.deployment-aws-region,
+          awslogs-stream-prefix = "solr-log"
+        },
+        secretOptions = []
       }
     },
     {
       name              = local.solr_container_name_api,
       systemControls    = [],
       image             = data.aws_ecr_image.solr["cudl-solr-api"].image_uri,
-      cpu               = 1024,
+      cpu               = floor(var.solr_ecs_task_def_cpu / 3),
       memory            = 1024,
-      memoryReservation = 1024,
+      memoryReservation = 512,
       portMappings = [
         {
           containerPort = var.solr_target_group_port,
@@ -85,19 +89,21 @@ locals {
           value = tostring(var.solr_target_group_port)
         },
         {
-          name  = "EXTRA_VAR"
-          value = "25"
+          name  = "NUM_WORKERS"
+          value = "3"
         }
       ],
       environmentFiles = [],
       mountPoints      = [],
       volumesFrom      = [],
       logConfiguration = {
-        logDriver = "syslog",
+        logDriver = "awslogs"
         options = {
-          syslog-address = "tcp://fluentd.sandbox-fluentd:5140"
-          tag            = local.solr_container_name_api
-        }
+          awslogs-group         = module.base_architecture.cloudwatch_log_group_name,
+          awslogs-region        = var.deployment-aws-region,
+          awslogs-stream-prefix = "solr-api-log"
+        },
+        secretOptions = []
       }
     },
 

--- a/cudl-sandbox/terraform.tfvars
+++ b/cudl-sandbox/terraform.tfvars
@@ -177,7 +177,7 @@ transform-lambda-information = [
   },
   {
     "name"                     = "AWSLambda_CUDLPackageData_TEI_Processing"
-    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-tei-processing@sha256:3b2ab95f0c963f9ac9ec1167a524db1c2d78f452cd5d535e27a10ca0603e45b8"
+    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-tei-processing@sha256:8b19952be936adcb5018ed37fe4cebbe86c2be82ae5a43b586745b37214c54bc"
     "queue_name"               = "CUDL_TEIProcessingQueue"
     "vpc_name"                 = "rmm98-sandbox-cudl-ecs-vpc"
     "subnet_names"             = ["rmm98-sandbox-cudl-ecs-subnet-private-a", "rmm98-sandbox-cudl-ecs-subnet-private-b"]
@@ -198,7 +198,7 @@ transform-lambda-information = [
   },
   {
     "name"                     = "AWSLambda_CUDLPackageData_SOLR_Listener"
-    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-solr-listener@sha256:b770b03827499abe460cedacd7d30ae4566f5acac4f03f00344ad1e35d6ea19e"
+    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-solr-listener@sha256:88795e469457966c06f62e55c1c217bef3b5fb92c35589bac4a5be735c631689"
     "queue_name"               = "CUDLIndexQueue"
     "vpc_name"                 = "rmm98-sandbox-cudl-ecs-vpc"
     "subnet_names"             = ["rmm98-sandbox-cudl-ecs-subnet-private-a", "rmm98-sandbox-cudl-ecs-subnet-private-b"]
@@ -207,7 +207,7 @@ transform-lambda-information = [
     "memory"                   = 1024
     "batch_window"             = 2
     "batch_size"               = 1
-    "maximum_concurrency"      = 100
+    "maximum_concurrency"      = 5
     "use_datadog_variables"    = false
     "use_additional_variables" = true
     "environment_variables" = {
@@ -218,7 +218,7 @@ transform-lambda-information = [
   },
   {
     "name"                     = "AWSLambda_CUDLPackageData_Collection_SOLR_Listener"
-    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-solr-listener@sha256:b770b03827499abe460cedacd7d30ae4566f5acac4f03f00344ad1e35d6ea19e"
+    "image_uri"                = "563181399728.dkr.ecr.eu-west-1.amazonaws.com/cudl-solr-listener@sha256:88795e469457966c06f62e55c1c217bef3b5fb92c35589bac4a5be735c631689"
     "queue_name"               = "CUDLIndexCollectionQueue"
     "vpc_name"                 = "rmm98-sandbox-cudl-ecs-vpc"
     "subnet_names"             = ["rmm98-sandbox-cudl-ecs-subnet-private-a", "rmm98-sandbox-cudl-ecs-subnet-private-b"]
@@ -227,7 +227,7 @@ transform-lambda-information = [
     "memory"                   = 1024
     "batch_window"             = 2
     "batch_size"               = 1
-    "maximum_concurrency"      = 100
+    "maximum_concurrency"      = 5
     "use_datadog_variables"    = false
     "use_additional_variables" = true
     "environment_variables" = {
@@ -291,6 +291,11 @@ registered_domain_name         = "cudl-sandbox.net."
 asg_desired_capacity           = 4 # n = number of tasks
 asg_max_size                   = 5 # n + 1
 asg_allow_all_egress           = true
+ec2_instance_type              = "t3.large"
+ec2_additional_userdata        = <<-EOF
+echo 1 > /proc/sys/vm/swappiness
+echo ECS_RESERVED_MEMORY=256 >> /etc/ecs/ecs.config
+EOF
 route53_delegation_set_id      = "N02288771HQRX5TRME6CM"
 route53_zone_id_existing       = "Z035173135AOVWW8L57UJ"
 route53_zone_force_destroy     = true
@@ -300,14 +305,16 @@ vpc_cidr_block                 = "10.42.0.0/22" #1024 adresses
 vpc_public_subnet_public_ip    = false
 vpc_peering_vpc_ids            = ["vpc-057886e0bdd7c4e43"]
 cloudwatch_log_group           = "/ecs/CUDLContent"
-vpc_endpoint_services          = ["ssmmessages", "ssm", "ec2messages", "ecr.api", "ecr.dkr", "ecs", "ecs-agent", "ecs-telemetry", "logs", "elasticfilesystem", "secretsmanager"]
 
 # Content Loader Workload
-content_loader_name_suffix              = "cl"
-content_loader_domain_name              = "contentloader"
-content_loader_application_port         = 8081
-content_loader_target_group_port        = 9009
-content_loader_ecr_repository_names     = ["dl-loader-db", "dl-loader-ui"]
+content_loader_name_suffix       = "cl"
+content_loader_domain_name       = "contentloader"
+content_loader_application_port  = 8081
+content_loader_target_group_port = 9009
+content_loader_ecr_repositories = {
+  "dl-loader-db" = "sha256:2f95f1e174623af80ddae2409771a07c0d1c71d7b83e4f42899b608810f70cab",
+  "dl-loader-ui" = "sha256:293c28a8f0f09456afae9af23efa65ea4a820410c5e14aad761950cd8c4e43d5"
+}
 content_loader_ecs_task_def_volumes     = { "dl-loader-db" = "/var/lib/postgresql/data" }
 content_loader_container_name_ui        = "dl-loader-ui"
 content_loader_container_name_db        = "dl-loader-db"
@@ -315,35 +322,41 @@ content_loader_health_check_status_code = "401"
 content_loader_allowed_methods          = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
 
 # SOLR Worload
-solr_name_suffix               = "solr"
-solr_domain_name               = "solr"
-solr_api_port                  = 80
-solr_application_port          = 8983
-solr_target_group_port         = 8081
-solr_ecr_repository_names      = ["cudl-solr-api", "cudl-solr"]
+solr_name_suffix       = "solr"
+solr_domain_name       = "solr"
+solr_api_port          = 80
+solr_application_port  = 8983
+solr_target_group_port = 8081
+solr_ecr_repositories = {
+  "cudl-solr-api" = "sha256:f5663ef09aa01c90a92057d161c4a3c83bb851137eb8b6dc1228d2727a130810",
+  "cudl-solr"     = "sha256:8dfcce2322e381d92bc02d19710afa8ec15e5a8f6c1efa1edddf550527c51fdb"
+}
 solr_ecs_task_def_volumes      = { "solr-volume" = "/var/solr" }
 solr_container_name_api        = "solr-api"
 solr_container_name_solr       = "solr"
 solr_health_check_status_code  = "404"
 solr_allowed_methods           = ["HEAD", "GET", "OPTIONS"]
-solr_ecs_task_def_cpu          = 1536
-solr_ecs_task_def_memory       = 1638
+solr_ecs_task_def_cpu          = 2048
 solr_use_service_discovery     = true
 solr_ingress_security_group_id = "sg-032f9f202ea602d21"
 
-cudl_services_name_suffix              = "cudl-services"
-cudl_services_domain_name              = "services"
-cudl_services_target_group_port        = 8085
-cudl_services_container_port           = 3000
-cudl_services_ecr_repository_names     = ["cudl-services"]
+cudl_services_name_suffix       = "cudl-services"
+cudl_services_domain_name       = "services"
+cudl_services_target_group_port = 8085
+cudl_services_container_port    = 3000
+cudl_services_ecr_repositories = {
+  "cudl-services" = "sha256:98b7ee01cca8c1093d3d719d13640db9f9d7e2439933d847a63e733d96f4660e"
+}
 cudl_services_health_check_status_code = "404"
 cudl_services_allowed_methods          = ["HEAD", "GET", "OPTIONS"]
 
-cudl_viewer_name_suffix                     = "cudl-viewer"
-cudl_viewer_domain_name                     = "cudl-viewer"
-cudl_viewer_target_group_port               = 5008
-cudl_viewer_container_port                  = 8080
-cudl_viewer_ecr_repository_names            = ["sandbox-cudl-viewer"]
+cudl_viewer_name_suffix       = "cudl-viewer"
+cudl_viewer_domain_name       = "cudl-viewer"
+cudl_viewer_target_group_port = 5008
+cudl_viewer_container_port    = 8080
+cudl_viewer_ecr_repositories = {
+  "sandbox-cudl-viewer" = "sha256:f05defe0682488c44d32aff6eed99d64091aef31700d9a724753b954cdc719f5"
+}
 cudl_viewer_health_check_status_code        = "200"
 cudl_viewer_allowed_methods                 = ["HEAD", "GET", "OPTIONS"]
 cudl_viewer_ecs_task_def_volumes            = { "cudl-viewer" = "/srv/cudl-viewer/cudl-data" }

--- a/cudl-sandbox/variables.tf
+++ b/cudl-sandbox/variables.tf
@@ -148,7 +148,11 @@ variable "cluster_name_suffix" {
 variable "ec2_instance_type" {
   type        = string
   description = "EC2 Instance type used by EC2 Instances"
-  default     = "t3.small"
+}
+
+variable "ec2_additional_userdata" {
+  type        = string
+  description = "Additional userdata to append to EC2 instances"
 }
 
 variable "asg_max_size" {
@@ -174,11 +178,6 @@ variable "vpc_cidr_block" {
 variable "vpc_public_subnet_public_ip" {
   type        = bool
   description = "Whether to automatically assign public IP addresses in the public subnets"
-}
-
-variable "vpc_endpoint_services" {
-  type        = list(string)
-  description = "List of services to create VPC Endpoints for"
 }
 
 variable "vpc_peering_vpc_ids" {
@@ -242,9 +241,9 @@ variable "content_loader_target_group_port" {
   description = "Port number to be used for the Content Loader Target Group"
 }
 
-variable "content_loader_ecr_repository_names" {
-  type        = list(string)
-  description = "List of ECR Repository names for Content Loader"
+variable "content_loader_ecr_repositories" {
+  type        = map(string)
+  description = "Map of ECR Repository name and digest values for Content Loader"
 }
 
 variable "content_loader_ecs_task_def_volumes" {
@@ -297,9 +296,9 @@ variable "solr_target_group_port" {
   description = "Port number to be used for the SOLR Target Group"
 }
 
-variable "solr_ecr_repository_names" {
-  type        = list(string)
-  description = "List of ECR Repository names for SOLR"
+variable "solr_ecr_repositories" {
+  type        = map(string)
+  description = "Map of ECR Repository name and digest values for SOLR"
 }
 
 variable "solr_ecs_task_def_volumes" {
@@ -332,11 +331,6 @@ variable "solr_ecs_task_def_cpu" {
   description = "Number of cpu units used by the SOLR tasks"
 }
 
-variable "solr_ecs_task_def_memory" {
-  type        = number
-  description = "Amount (in MiB) of memory used by the SOLR tasks"
-}
-
 variable "solr_use_service_discovery" {
   type        = bool
   description = "Whether SOLR should use Service Discovery"
@@ -367,9 +361,9 @@ variable "cudl_services_container_port" {
   description = "Port number to be used for the CUDL services Container"
 }
 
-variable "cudl_services_ecr_repository_names" {
-  type        = list(string)
-  description = "List of ECR Repository names for CUDL Services"
+variable "cudl_services_ecr_repositories" {
+  type        = map(string)
+  description = "Map of ECR Repository name and digest values for CUDL Services"
 }
 
 
@@ -408,9 +402,9 @@ variable "cudl_viewer_container_port" {
   description = "Port number to be used for the CUDL viewer Container"
 }
 
-variable "cudl_viewer_ecr_repository_names" {
-  type        = list(string)
-  description = "List of ECR Repository names for CUDL viewer"
+variable "cudl_viewer_ecr_repositories" {
+  type        = map(string)
+  description = "Map of ECR Repository name and digest values for CUDL viewer"
 }
 
 


### PR DESCRIPTION
- Update version of base_architecture module to v2.1.0
- Update maximum_concurrency of SOLR_Listener and Collection_SOLR_Listener lambdas
- Replace ecr_repository_names list variables with ecr_repositories map variables
- Update data.aws_ecr_image data blocks with image_digest arguments in place of image_tag
- Add local variable solr_ecs_task_def_memory
- Add ec2_additional_userdata variable
- Remove vpc_endpoint_services and solr_ecs_task_def_memory variables
- Update local.solr_container_defs to use awslogs logging driver, update values for cpu, memory and memoryReservation, add SOLR_HEAP and NUM_WORKERS environment variables