### PR TITLE
Refactor `cudl-data-processing` module 

### DIFF
--- a/cul-cudl-production/cudl_services_container_def.tf
+++ b/cul-cudl-production/cudl_services_container_def.tf
@@ -37,7 +37,7 @@ locals {
         },
         {
           name  = "CUDL_SERVICES_TEI_HTML_URL",
-          value = "https://${module.cudl-data-processing.transcriptions_domain_name}/"
+          value = "https://${module.cudl-data-processing.cloudfront_distribution_domain_name}/"
         },
         {
           name  = "CUDL_SERVICES_XTF_INDEX_PATH",

--- a/cul-cudl-staging/cudl_services_container_def.tf
+++ b/cul-cudl-staging/cudl_services_container_def.tf
@@ -37,7 +37,7 @@ locals {
         },
         {
           name  = "CUDL_SERVICES_TEI_HTML_URL",
-          value = "https://${module.cudl-data-processing.transcriptions_domain_name}/"
+          value = "https://${module.cudl-data-processing.cloudfront_distribution_domain_name}/"
         },
         {
           name  = "CUDL_SERVICES_XTF_INDEX_PATH",

--- a/modules/cudl-data-processing/acm.tf
+++ b/modules/cudl-data-processing/acm.tf
@@ -1,10 +1,10 @@
-resource "aws_acm_certificate" "transcriptions" {
+resource "aws_acm_certificate" "this" {
   count = var.acm_create_certificate && var.create_cloudfront_distribution ? 1 : 0
 
-  domain_name       = local.transcriptions_domain_name
+  domain_name       = local.cloudfront_distribution_domain_name
   validation_method = "DNS"
   subject_alternative_names = [
-    local.transcriptions_domain_name
+    local.cloudfront_distribution_domain_name
   ]
 
   lifecycle {
@@ -12,25 +12,25 @@ resource "aws_acm_certificate" "transcriptions" {
   }
 }
 
-resource "aws_acm_certificate_validation" "transcriptions" {
+resource "aws_acm_certificate_validation" "this" {
   count = var.acm_create_certificate && var.create_cloudfront_distribution ? 1 : 0
 
-  certificate_arn         = aws_acm_certificate.transcriptions.0.arn
-  validation_record_fqdns = [for record in aws_route53_record.transcriptions_acm_validation_cname : record.fqdn]
+  certificate_arn         = aws_acm_certificate.this.0.arn
+  validation_record_fqdns = [for record in aws_route53_record.acm_validation_cname : record.fqdn]
 
   timeouts {
     create = "10m"
   }
 }
 
-resource "aws_acm_certificate" "transcriptions_us-east-1" {
+resource "aws_acm_certificate" "this_us-east-1" {
   count = var.acm_create_certificate && var.create_cloudfront_distribution ? 1 : 0
 
   provider          = aws.us-east-1
-  domain_name       = local.transcriptions_domain_name
+  domain_name       = local.cloudfront_distribution_domain_name
   validation_method = "DNS"
   subject_alternative_names = [
-    local.transcriptions_domain_name
+    local.cloudfront_distribution_domain_name
   ]
 
   lifecycle {

--- a/modules/cudl-data-processing/cloudfront.tf
+++ b/modules/cudl-data-processing/cloudfront.tf
@@ -3,7 +3,7 @@ data "aws_cloudfront_cache_policy" "managed_caching_disabled" {
   name     = "Managed-CachingDisabled"
 }
 
-resource "aws_cloudfront_origin_access_control" "transcriptions" {
+resource "aws_cloudfront_origin_access_control" "this" {
   count = var.create_cloudfront_distribution ? 1 : 0
 
   name                              = aws_s3_bucket.dest-bucket.id
@@ -13,25 +13,25 @@ resource "aws_cloudfront_origin_access_control" "transcriptions" {
   signing_protocol                  = "sigv4"
 }
 
-resource "aws_cloudfront_distribution" "transcriptions" {
+resource "aws_cloudfront_distribution" "this" {
   count = var.create_cloudfront_distribution ? 1 : 0
 
   provider = aws.us-east-1
 
-  comment      = "${local.transcriptions_domain_name} CloudFront Distribution"
+  comment      = "${local.cloudfront_distribution_domain_name} CloudFront Distribution"
   price_class  = "PriceClass_100"
   enabled      = true
   http_version = "http2"
-  web_acl_id   = aws_wafv2_web_acl.transcriptions.0.arn
+  web_acl_id   = aws_wafv2_web_acl.this.0.arn
 
   aliases = [
-    local.transcriptions_domain_name
+    local.this_domain_name
   ]
 
   origin {
     domain_name              = aws_s3_bucket.dest-bucket.bucket_regional_domain_name
-    origin_id                = local.transcriptions_domain_name
-    origin_access_control_id = aws_cloudfront_origin_access_control.transcriptions.0.id
+    origin_id                = local.cloudfront_distribution_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.0.id
   }
 
   default_cache_behavior {
@@ -39,13 +39,13 @@ resource "aws_cloudfront_distribution" "transcriptions" {
     cached_methods         = ["GET", "HEAD"]
     compress               = true
     smooth_streaming       = false
-    target_origin_id       = local.transcriptions_domain_name
+    target_origin_id       = local.cloudfront_distribution_domain_name
     viewer_protocol_policy = "redirect-to-https"
     cache_policy_id        = data.aws_cloudfront_cache_policy.managed_caching_disabled.id
   }
 
   viewer_certificate {
-    acm_certificate_arn            = var.acm_create_certificate ? aws_acm_certificate.transcriptions_us-east-1.0.arn : var.acm_certificate_arn
+    acm_certificate_arn            = var.acm_create_certificate ? aws_acm_certificate.this_us-east-1.0.arn : var.acm_certificate_arn
     cloudfront_default_certificate = false
     minimum_protocol_version       = "TLSv1.2_2021"
     ssl_support_method             = "sni-only"

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -40,5 +40,5 @@ locals {
     replace(bucket.id, lower("${var.environment}-"), "") => bucket
   }
 
-  transcriptions_domain_name = var.create_cloudfront_distribution ? var.production_deployment ? "transcriptions.${data.aws_route53_zone.domain.0.name}" : "${var.environment}-transcriptions.${data.aws_route53_zone.domain.0.name}" : ""
+  cloudfront_distribution_domain_name = var.create_cloudfront_distribution ? var.production_deployment ? join(".", [var.cloudfront_distribution_name, data.aws_route53_zone.domain.0.name]) : join(".", [var.environment, var.cloudfront_distribution_name, data.aws_route53_zone.domain.0.name]) : ""
 }

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -40,5 +40,5 @@ locals {
     replace(bucket.id, lower("${var.environment}-"), "") => bucket
   }
 
-  cloudfront_distribution_domain_name = var.create_cloudfront_distribution ? var.production_deployment ? join(".", [var.cloudfront_distribution_name, data.aws_route53_zone.domain.0.name]) : join(".", [var.environment, var.cloudfront_distribution_name, data.aws_route53_zone.domain.0.name]) : ""
+  cloudfront_distribution_domain_name = var.create_cloudfront_distribution ? var.production_deployment ? join(".", [var.cloudfront_distribution_name, data.aws_route53_zone.domain.0.name]) : join(".", [join("-", [var.environment, var.cloudfront_distribution_name]), data.aws_route53_zone.domain.0.name]) : ""
 }

--- a/modules/cudl-data-processing/moved.tf
+++ b/modules/cudl-data-processing/moved.tf
@@ -1,0 +1,19 @@
+moved {
+  from = aws_cloudfront_origin_access_control.transcriptions
+  to   = aws_cloudfront_origin_access_control.this
+}
+
+moved {
+  from = aws_cloudfront_distribution.transcriptions
+  to   = aws_cloudfront_distribution.this
+}
+
+moved {
+  from = aws_route53_record.transcriptions_cloudfront_alias
+  to   = aws_route53_record.cloudfront_alias
+}
+
+moved {
+  from = aws_wafv2_web_acl.transcriptions
+  to   = aws_wafv2_web_acl.this
+}

--- a/modules/cudl-data-processing/outputs.tf
+++ b/modules/cudl-data-processing/outputs.tf
@@ -38,6 +38,6 @@ output "efs_security_group_id" {
   value = aws_security_group.efs.id
 }
 
-output "transcriptions_domain_name" {
-  value = local.transcriptions_domain_name
+output "cloudfront_distribution_domain_name" {
+  value = local.cloudfront_distribution_domain_name
 }

--- a/modules/cudl-data-processing/route53.tf
+++ b/modules/cudl-data-processing/route53.tf
@@ -4,22 +4,22 @@ data "aws_route53_zone" "domain" {
   zone_id = var.cloudfront_route53_zone_id
 }
 
-resource "aws_route53_record" "transcriptions_cloudfront_alias" {
+resource "aws_route53_record" "cloudfront_alias" {
   count = var.create_cloudfront_distribution ? 1 : 0
 
-  name = local.transcriptions_domain_name # NOTE match CloudFront Distribution alias
+  name = local.cloudfront_distribution_domain_name # NOTE match CloudFront Distribution alias
   type = "A"
   alias {
-    name                   = aws_cloudfront_distribution.transcriptions.0.domain_name
-    zone_id                = aws_cloudfront_distribution.transcriptions.0.hosted_zone_id
+    name                   = aws_cloudfront_distribution.this.0.domain_name
+    zone_id                = aws_cloudfront_distribution.this.0.hosted_zone_id
     evaluate_target_health = false
   }
   zone_id = data.aws_route53_zone.domain.0.zone_id
 }
 
-resource "aws_route53_record" "transcriptions_acm_validation_cname" {
+resource "aws_route53_record" "acm_validation_cname" {
   for_each = var.acm_create_certificate && var.create_cloudfront_distribution ? {
-    for dvo in aws_acm_certificate.transcriptions.0.domain_validation_options : dvo.domain_name => {
+    for dvo in aws_acm_certificate.this.0.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type

--- a/modules/cudl-data-processing/s3.tf
+++ b/modules/cudl-data-processing/s3.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "dest-bucket" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
-      values   = [aws_cloudfront_distribution.transcriptions.0.arn]
+      values   = [aws_cloudfront_distribution.this.0.arn]
     }
   }
 }

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -197,6 +197,18 @@ variable "cloudfront_distribution_name" {
   default     = "transcriptions"
 }
 
+variable "cloudfront_origin_path" {
+  description = "Origin path in an S3 Bucket or custom origin"
+  type        = string
+  default     = null
+}
+
+variable "cloudfront_viewer_request_function_arn" {
+  type        = string
+  description = "ARN of a CloudFront Function to add to CloudFront Distribution to handle Viewer Requests"
+  default     = null
+}
+
 variable "efs_nfs_mount_port" {
   type        = number
   description = "NFS protocol port for EFS mounts"

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -191,6 +191,12 @@ variable "cloudfront_route53_zone_id" {
   default     = null
 }
 
+variable "cloudfront_distribution_name" {
+  description = "Name of the CloudFront Distribution and associated resources"
+  type        = string
+  default     = "transcriptions"
+}
+
 variable "efs_nfs_mount_port" {
   type        = number
   description = "NFS protocol port for EFS mounts"

--- a/modules/cudl-data-processing/waf.tf
+++ b/modules/cudl-data-processing/waf.tf
@@ -1,9 +1,9 @@
-resource "aws_wafv2_web_acl" "transcriptions" {
+resource "aws_wafv2_web_acl" "this" {
   count = var.create_cloudfront_distribution ? 1 : 0
 
-  name        = "${var.environment}-transcriptions-waf-web-acl"
+  name        = join("-", [var.environment, var.cloudfront_distribution_name, "waf-web-acl"])
   provider    = aws.us-east-1
-  description = "Managed by Terraform for ${var.environment}"
+  description = "Managed by Terraform for ${var.environment} ${var.cloudfront_distribution_name}"
   scope       = "CLOUDFRONT"
 
   default_action {
@@ -86,7 +86,7 @@ resource "aws_wafv2_web_acl" "transcriptions" {
 
   visibility_config {
     cloudwatch_metrics_enabled = true
-    metric_name                = "transcriptions-waf-web-acl-no-rule"
+    metric_name                = join("-", [var.environment, var.cloudfront_distribution_name, "waf-web-acl-no-rule"])
     sampled_requests_enabled   = true
   }
 }


### PR DESCRIPTION
- Rename resources labelled `transcriptions` to use label `this`
- Add variable `cloudfront_distribution_name` with default value "transcriptions"
- Replace `local.transcriptions_domain_name` with `local.cloudfront_distribution_domain_name`
- Rename WAF resources using `cloudfront_distribution_name` variable
- Add optional origin path on CloudFront distribution origin
- Add optional viewer request function
- Add new variables `cloudfront_viewer_request_function_arn` and `cloudfront_origin_path`
- Add modules/cudl-data-processing/moved.tf with moved blocks for renamed resources
- Update `local.cloudfront_distribution_domain_name` to match values in current deployments
- Update `CUDL_SERVICES_TEI_HTML_URL` environment variable in `cul-cudl-staging`
- Update `CUDL_SERVICES_TEI_HTML_URL` environment variable in `cul-cudl-production`