### PR TITLE
Add `default_root_object` argument to CloudFront in `cudl-data-processing` module

### DIFF
--- a/modules/cudl-data-processing/cloudfront.tf
+++ b/modules/cudl-data-processing/cloudfront.tf
@@ -18,11 +18,12 @@ resource "aws_cloudfront_distribution" "this" {
 
   provider = aws.us-east-1
 
-  comment      = "${local.cloudfront_distribution_domain_name} CloudFront Distribution"
-  price_class  = "PriceClass_100"
-  enabled      = true
-  http_version = "http2"
-  web_acl_id   = aws_wafv2_web_acl.this.0.arn
+  comment             = "${local.cloudfront_distribution_domain_name} CloudFront Distribution"
+  price_class         = "PriceClass_100"
+  enabled             = true
+  http_version        = "http2"
+  web_acl_id          = aws_wafv2_web_acl.this.0.arn
+  default_root_object = var.cloudfront_default_root_object
 
   aliases = [
     local.cloudfront_distribution_domain_name

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -209,6 +209,12 @@ variable "cloudfront_viewer_request_function_arn" {
   default     = null
 }
 
+variable "cloudfront_default_root_object" {
+  type        = string
+  description = "Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL"
+  default     = null
+}
+
 variable "efs_nfs_mount_port" {
   type        = number
   description = "NFS protocol port for EFS mounts"


### PR DESCRIPTION
- Add `default_root_object` argument to `aws_cloudfront_distribution.this` in `modules/cudl-data-processing/cloudfront.tf`
- Add variable `cloudfront_default_root_object` in `modules/ cudl-data-processing/cloudfront.tf`