### PR TITLE
fix(s3): Fix long names of S3 buckets in cudl-data-processing module

### DIFF
--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -1,6 +1,10 @@
 locals {
 
-  transform-lambda-bucket-names = toset([var.source-bucket-name, var.destination-bucket-name, var.enhancements-bucket-name])
+  transform-lambda-bucket-names = toset([for bucket in [
+    aws_s3_bucket.source-bucket.id,
+    aws_s3_bucket.dest-bucket.id,
+    aws_s3_bucket.enhancements-bucket.id
+  ] : replace(bucket, lower(format("%s-", var.environment)), "")])
 
   transform_sns_subscriptions = flatten([
     for index, notification in var.transform-lambda-bucket-sns-notifications : [

--- a/modules/cudl-data-processing/s3.tf
+++ b/modules/cudl-data-processing/s3.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket" "dest-bucket" {
-  bucket = lower("${var.environment}-${var.destination-bucket-name}")
+  bucket = trimsuffix(substr(lower("${var.environment}-${var.destination-bucket-name}"), 0, 63), "-")
 }
 
 resource "aws_s3_bucket" "source-bucket" {
-  bucket = lower("${var.environment}-${var.source-bucket-name}")
+  bucket = trimsuffix(substr(lower("${var.environment}-${var.source-bucket-name}"), 0, 63), "-")
 }
 
 resource "aws_s3_bucket" "enhancements-bucket" {
-  bucket = lower("${var.environment}-${var.enhancements-bucket-name}")
+  bucket = trimsuffix(substr(lower("${var.environment}-${var.enhancements-bucket-name}"), 0, 63), "-")
 }
 
 data "aws_iam_policy_document" "dest-bucket" {


### PR DESCRIPTION
- Update names of S3 buckets in `cudl-data-processing` module using `substr` and `trimsuffix` functions to prevent names longer than 64 characters
- Update `local.transform-lambda-bucket-names` variable using ids of `aws_s3_bucket` resources to ensure values match trimmed bucket names