### PR TITLE
feat(cloudwatch): Add CloudWatch subscription filter in cul-cudl account

### DIFF
--- a/cul-cudl-staging/cloudwatch.tf
+++ b/cul-cudl-staging/cloudwatch.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudwatch_log_subscription_filter" "logging_destination" {
+  name            = format("%s-logging-destination", local.base_name_prefix)
+  log_group_name  = module.base_architecture.cloudwatch_log_group_name
+  filter_pattern  = ""
+  destination_arn = var.cloudwatch_log_destination_arn
+  distribution    = "ByLogStream"
+}

--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -300,6 +300,7 @@ alb_idle_timeout               = "900"
 vpc_cidr_block                 = "10.88.0.0/22" #1024 adresses
 vpc_public_subnet_public_ip    = false
 cloudwatch_log_group           = "/ecs/CUDL"
+cloudwatch_log_destination_arn = "arn:aws:logs:eu-west-1:874581676011:destination:cul-logs-cloudwatch-log-destination"
 vpc_endpoint_services          = ["ssmmessages", "ssm", "ec2messages", "ecr.api", "ecr.dkr", "ecs", "ecs-agent", "ecs-telemetry", "logs", "elasticfilesystem", "secretsmanager"]
 
 # Content Loader Workload

--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -299,7 +299,7 @@ alb_enable_deletion_protection = false
 alb_idle_timeout               = "900"
 vpc_cidr_block                 = "10.88.0.0/22" #1024 adresses
 vpc_public_subnet_public_ip    = false
-cloudwatch_log_group           = "/ecs/CUDL"
+cloudwatch_log_group           = "/ecs/CUDL-Staging"
 cloudwatch_log_destination_arn = "arn:aws:logs:eu-west-1:874581676011:destination:cul-logs-cloudwatch-log-destination"
 vpc_endpoint_services          = ["ssmmessages", "ssm", "ec2messages", "ecr.api", "ecr.dkr", "ecs", "ecs-agent", "ecs-telemetry", "logs", "elasticfilesystem", "secretsmanager"]
 

--- a/cul-cudl-staging/variables.tf
+++ b/cul-cudl-staging/variables.tf
@@ -226,6 +226,11 @@ variable "cloudwatch_log_group" {
   description = "Name of the cloudwatch log group"
 }
 
+variable "cloudwatch_log_destination_arn" {
+  type        = string
+  description = "ARN of a CloudWatch Log Destination"
+}
+
 variable "content_loader_name_suffix" {
   type        = string
   description = "Suffix to add to Content Loader resource names"


### PR DESCRIPTION
- Add `aws_cloudwatch_log_subscription_filter.logging_destination` resource in `cul-cudl-staging/cloudwatch.tf`
- Add variable `cloudwatch_log_destination_arn` in `cul-cudl-staging/variables.tf` and `terraform.tfvars`