### PR TITLE
Add custom error response to CloudFront and fix issue with local.transform-lambda-bucket-names

### DIFF
--- a/modules/cudl-data-processing/cloudfront.tf
+++ b/modules/cudl-data-processing/cloudfront.tf
@@ -54,6 +54,17 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
+  dynamic "custom_error_response" {
+    for_each = var.cloudfront_error_response_page_path != null ? [1] : []
+
+    content {
+      error_code            = var.cloudfront_error_code_to_catch
+      response_code         = var.cloudfront_error_response_code
+      response_page_path    = var.cloudfront_error_response_page_path
+      error_caching_min_ttl = var.cloudfront_error_caching_min_ttl
+    }
+  }
+
   viewer_certificate {
     acm_certificate_arn            = var.acm_create_certificate ? aws_acm_certificate.this_us-east-1.0.arn : var.acm_certificate_arn
     cloudfront_default_certificate = false

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -1,9 +1,11 @@
 locals {
-
+  destination_bucket_name = trimsuffix(substr(lower("${var.environment}-${var.destination-bucket-name}"), 0, 63), "-")
+  enhacements_bucket_name = trimsuffix(substr(lower("${var.environment}-${var.enhancements-bucket-name}"), 0, 63), "-")
+  source_bucket_name = trimsuffix(substr(lower("${var.environment}-${var.source-bucket-name}"), 0, 63), "-")
   transform-lambda-bucket-names = toset([for bucket in [
-    aws_s3_bucket.source-bucket.id,
-    aws_s3_bucket.dest-bucket.id,
-    aws_s3_bucket.enhancements-bucket.id
+    local.destination_bucket_name,
+    local.enhacements_bucket_name,
+    local.source_bucket_name
   ] : replace(bucket, lower(format("%s-", var.environment)), "")])
 
   transform_sns_subscriptions = flatten([

--- a/modules/cudl-data-processing/outputs.tf
+++ b/modules/cudl-data-processing/outputs.tf
@@ -30,6 +30,14 @@ output "destination_bucket" {
   value = aws_s3_bucket.dest-bucket.id
 }
 
+output "destination_bucket_arn" {
+  value = aws_s3_bucket.dest-bucket.arn
+}
+
+output "destination_regional_domain_name" {
+  value = aws_s3_bucket.dest-bucket.bucket_regional_domain_name
+}
+
 output "efs_file_system_id" {
   value = aws_efs_file_system.efs-volume.id
 }

--- a/modules/cudl-data-processing/s3.tf
+++ b/modules/cudl-data-processing/s3.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket" "dest-bucket" {
-  bucket = trimsuffix(substr(lower("${var.environment}-${var.destination-bucket-name}"), 0, 63), "-")
+  bucket = local.destination_bucket_name
 }
 
 resource "aws_s3_bucket" "source-bucket" {
-  bucket = trimsuffix(substr(lower("${var.environment}-${var.source-bucket-name}"), 0, 63), "-")
+  bucket = local.source_bucket_name
 }
 
 resource "aws_s3_bucket" "enhancements-bucket" {
-  bucket = trimsuffix(substr(lower("${var.environment}-${var.enhancements-bucket-name}"), 0, 63), "-")
+  bucket = local.enhacements_bucket_name
 }
 
 data "aws_iam_policy_document" "dest-bucket" {

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -203,6 +203,30 @@ variable "cloudfront_origin_path" {
   default     = null
 }
 
+variable "cloudfront_error_response_page_path" {
+  description = "S3 Bucket path with a custom error page html"
+  type        = string
+  default     = null
+}
+
+variable "cloudfront_error_code_to_catch" {
+  description = "CloudFront error code to catch in custom error handling"
+  type        = number
+  default     = 403
+}
+
+variable "cloudfront_error_response_code" {
+  description = "CloudFront error code to use in custom error handling"
+  type        = number
+  default     = 404
+}
+
+variable "cloudfront_error_caching_min_ttl" {
+  description = "Minimum amount of time you want HTTP error codes to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated"
+  type        = number
+  default     = 60
+}
+
 variable "cloudfront_viewer_request_function_arn" {
   type        = string
   description = "ARN of a CloudFront Function to add to CloudFront Distribution to handle Viewer Requests"


### PR DESCRIPTION
Add custom error response to CloudFront Distribution in `cudl-data-processing` module:
- Add dynamic `custom_error_response` block to `aws_cloudfront_distribution.this`
- Add outputs `destination_bucket_arn` and `destination_regional_domain_name`
- Add variables `cloudfront_error_response_page_path`, `cloudfront_error_code_to_catch`, `cloudfront_error_response_code` and `cloudfront_error_caching_min_ttl`

Fix error: the "for_each" set includes values derived from resource attributes that cannot be determined until apply
- Add local variables `destination_bucket_name`, `enhacements_bucket_name` and `source_bucket_name`
- Use local variables in `aws_s3_bucket` `bucket` arguments
- Use local variables in `local.transform-lambda-bucket-names`
