### PR TITLE
Add further aliases to the CloudFront Distribution

### DIFF
--- a/modules/cudl-data-processing/cloudfront.tf
+++ b/modules/cudl-data-processing/cloudfront.tf
@@ -25,9 +25,9 @@ resource "aws_cloudfront_distribution" "this" {
   web_acl_id          = aws_wafv2_web_acl.this.0.arn
   default_root_object = var.cloudfront_default_root_object
 
-  aliases = [
+  aliases = concat([
     local.cloudfront_distribution_domain_name
-  ]
+  ], var.cloudfront_alternative_domain_names)
 
   origin {
     domain_name              = aws_s3_bucket.dest-bucket.bucket_regional_domain_name

--- a/modules/cudl-data-processing/locals.tf
+++ b/modules/cudl-data-processing/locals.tf
@@ -1,7 +1,7 @@
 locals {
   destination_bucket_name = trimsuffix(substr(lower("${var.environment}-${var.destination-bucket-name}"), 0, 63), "-")
   enhacements_bucket_name = trimsuffix(substr(lower("${var.environment}-${var.enhancements-bucket-name}"), 0, 63), "-")
-  source_bucket_name = trimsuffix(substr(lower("${var.environment}-${var.source-bucket-name}"), 0, 63), "-")
+  source_bucket_name      = trimsuffix(substr(lower("${var.environment}-${var.source-bucket-name}"), 0, 63), "-")
   transform-lambda-bucket-names = toset([for bucket in [
     local.destination_bucket_name,
     local.enhacements_bucket_name,

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -239,6 +239,12 @@ variable "cloudfront_default_root_object" {
   default     = null
 }
 
+variable "cloudfront_alternative_domain_names" {
+  type        = list(string)
+  description = "List of additional domain names to add to the CloudFront distribution"
+  default     = []
+}
+
 variable "efs_nfs_mount_port" {
   type        = number
   description = "NFS protocol port for EFS mounts"


### PR DESCRIPTION
- Update `aliases` argument of `aws_cloudfront_distribution.this` in `cudl-data-processing` module
- Add input variable `cloudfront_alternative_domain_names`
- Run `terraform fmt`