### PR TITLE
fix(production): Fix memory and memoryReservation for cudl-viewer

### DIFF
--- a/cul-cudl-production/cudl_viewer_container_def.tf
+++ b/cul-cudl-production/cudl_viewer_container_def.tf
@@ -7,8 +7,8 @@ locals {
       name              = local.cudl_viewer_container_name,
       image             = data.aws_ecr_image.cudl_viewer["cudl/viewer"].image_uri,
       cpu               = 2048,
-      memoryReservation = data.aws_ec2_instance_type.asg.memory_size - 1024,
-      memory            = data.aws_ec2_instance_type.asg.memory_size - 512,
+      memoryReservation = data.aws_ec2_instance_type.asg.memory_size - 1104,
+      memory            = data.aws_ec2_instance_type.asg.memory_size - 592,
       portMappings = [
         {
           containerPort = var.cudl_viewer_container_port,
@@ -36,8 +36,7 @@ locals {
           awslogs-group         = module.base_architecture.cloudwatch_log_group_name,
           awslogs-region        = var.deployment-aws-region,
           awslogs-stream-prefix = "ecs/${local.cudl_viewer_container_name}"
-        },
-        secretOptions = []
+        }
       }
     }
   ]

--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -158,7 +158,7 @@ module "cudl_viewer" {
   ecs_network_mode                          = "awsvpc"
   ecs_task_def_container_definitions        = jsonencode(local.cudl_viewer_container_defs)
   ecs_task_def_volumes                      = keys(var.cudl_viewer_ecs_task_def_volumes)
-  ecs_task_def_memory                       = data.aws_ec2_instance_type.asg.memory_size - 512
+  ecs_task_def_memory                       = data.aws_ec2_instance_type.asg.memory_size - 592
   ecs_service_container_name                = local.cudl_viewer_container_name
   ecs_service_container_port                = var.cudl_viewer_container_port
   ecs_service_capacity_provider_name        = module.base_architecture.ecs_capacity_provider_name


### PR DESCRIPTION
- Reduce values for `memory` and `memoryReservation` in `local .cudl_viewer_container_defs` to align with version 11 of the task definition
- Reduce value of `ecs_task_def_memory` in cudl_viewer module
- Remove unused `secretOptions` from log configuration of `local.cudl_viewer_container_defs`

ECS is struggling to deploy a change to the task definition version made earlier today. The version changed from version 11 to version 8. The primary differences between these versions are in the memory and memoryReservation settings. The memory in version 8 is 7680; the value in version 11 is 7600. The memoryReservation in version 8 is 7168; the value in version 11 is 7088. Given that `data.aws_ec2_instance_type.asg.memory_size` is 8192, this change restores the values in version 11, which is deployable. It seems the value of `data.aws_ec2_instance_type.asg.memory_size` may have changed from 8112 when version 11 was deployed to 8192 now. However the lower value is more correct as no instance with 8GB memory is able to deploy version 8 of the task definition 