### PR TITLE
Update sandbox image versions and properties

### DIFF
--- a/cudl-sandbox/locals.tf
+++ b/cudl-sandbox/locals.tf
@@ -20,5 +20,5 @@ locals {
     AWS_CUDL_DATA_SOURCE_BUCKET = "${local.environment}-cudl-data-source"
     AWS_OUTPUT_BUCKET           = "${local.environment}-cudl-data-source"
   }
-  solr_ecs_task_def_memory = data.aws_ec2_instance_type.asg.memory_size - 768
+  solr_ecs_task_def_memory = data.aws_ec2_instance_type.asg.memory_size - 512
 }

--- a/cudl-sandbox/main.tf
+++ b/cudl-sandbox/main.tf
@@ -210,6 +210,7 @@ module "cudl_viewer" {
       smtp_password = var.cudl_viewer_smtp_password
       mount_path    = var.cudl_viewer_ecs_task_def_volumes["cudl-viewer"]
       search_url    = format("http://%s:%s/", trimsuffix(module.solr.private_access_host, "."), var.solr_target_group_port)
+      services_url  = module.cudl_services.link
     })
   }
   s3_task_buckets                        = [module.base_architecture.s3_bucket]

--- a/cudl-sandbox/main.tf
+++ b/cudl-sandbox/main.tf
@@ -31,7 +31,7 @@ module "cudl-data-processing" {
 }
 
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.1.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.2.0"
 
   name_prefix                    = local.base_name_prefix
   ec2_instance_type              = var.ec2_instance_type
@@ -47,11 +47,12 @@ module "base_architecture" {
   cloudwatch_log_group           = var.cloudwatch_log_group # TODO create log group
   vpc_cidr_block                 = var.vpc_cidr_block
   waf_use_ip_restrictions        = true
+  waf_use_rate_limiting          = true
   tags                           = local.default_tags
 }
 
 module "content_loader" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.1"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.4.0"
 
   name_prefix                               = join("-", compact([local.environment, var.content_loader_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id
@@ -96,7 +97,7 @@ module "content_loader" {
 }
 
 module "solr" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.1"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.4.0"
 
   name_prefix                                    = join("-", compact([local.environment, var.solr_name_suffix]))
   account_id                                     = data.aws_caller_identity.current.account_id
@@ -152,7 +153,7 @@ module "solr_stopped_tasks" {
 }
 
 module "cudl_services" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.1"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.4.0"
 
   name_prefix                               = join("-", compact([local.environment, var.cudl_services_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id
@@ -187,7 +188,7 @@ module "cudl_services" {
 }
 
 module "cudl_viewer" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.1"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.4.0"
 
   name_prefix                               = join("-", compact([local.environment, var.cudl_viewer_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id

--- a/cudl-sandbox/templates/viewer/cudl-global.properties.ttfpl
+++ b/cudl-sandbox/templates/viewer/cudl-global.properties.ttfpl
@@ -13,7 +13,7 @@ cudl-viewer-content.images.path=${mount_path}/pages/images
 # enable.refresh enables a URL on /refresh to allow you to refresh the items/collections in the cache.
 # caching.enabled prevents items from being cached and regularly refreshed the db.
 enable.refresh=true
-caching.enabled=false
+caching.enabled=true
 
 # Value to append to image server URL
 appendToThumbnail=.jp2/full/,180/0/default.jpg
@@ -40,7 +40,7 @@ dataUIThemeResources=${mount_path}/ui/
 # URLs for image and services servers.
 # Note after switch to IIIF (thumbnail data) we can remove IIIFImageServer
 imageServer=https://images.lib.cam.ac.uk/
-services=http://cudl-services/
+services=${services_url}
 IIIFImageServer=https://images.lib.cam.ac.uk/iiif/
 
 # Email address to send the feedback form to.

--- a/cudl-sandbox/templates/viewer/cudl-global.properties.ttfpl
+++ b/cudl-sandbox/templates/viewer/cudl-global.properties.ttfpl
@@ -15,6 +15,10 @@ cudl-viewer-content.images.path=${mount_path}/pages/images
 enable.refresh=true
 caching.enabled=false
 
+# Value to append to image server URL
+appendToThumbnail=.jp2/full/,180/0/default.jpg
+appendToImage=.jp2
+
 # DEV Id.
 GoogleAnalyticsId=UA\
   -10976633-2

--- a/cudl-sandbox/terraform.tfvars
+++ b/cudl-sandbox/terraform.tfvars
@@ -355,7 +355,7 @@ cudl_viewer_domain_name       = "cudl-viewer"
 cudl_viewer_target_group_port = 5008
 cudl_viewer_container_port    = 8080
 cudl_viewer_ecr_repositories = {
-  "sandbox-cudl-viewer" = "sha256:9d66b07a6d2e6f55f1f33882715149191d113ffcb37253126137264e208f1b63"
+  "sandbox-cudl-viewer" = "sha256:8af91b68471dcd20ebed2a116f26c91c0796529194982fab784f1ebfa1944369"
 }
 cudl_viewer_health_check_status_code        = "200"
 cudl_viewer_allowed_methods                 = ["HEAD", "GET", "OPTIONS"]

--- a/cudl-sandbox/terraform.tfvars
+++ b/cudl-sandbox/terraform.tfvars
@@ -291,7 +291,7 @@ registered_domain_name         = "cudl-sandbox.net."
 asg_desired_capacity           = 4 # n = number of tasks
 asg_max_size                   = 5 # n + 1
 asg_allow_all_egress           = true
-ec2_instance_type              = "t3.large"
+ec2_instance_type              = "t3.small"
 ec2_additional_userdata        = <<-EOF
 echo 1 > /proc/sys/vm/swappiness
 echo ECS_RESERVED_MEMORY=256 >> /etc/ecs/ecs.config
@@ -355,7 +355,7 @@ cudl_viewer_domain_name       = "cudl-viewer"
 cudl_viewer_target_group_port = 5008
 cudl_viewer_container_port    = 8080
 cudl_viewer_ecr_repositories = {
-  "sandbox-cudl-viewer" = "sha256:f05defe0682488c44d32aff6eed99d64091aef31700d9a724753b954cdc719f5"
+  "sandbox-cudl-viewer" = "sha256:9d66b07a6d2e6f55f1f33882715149191d113ffcb37253126137264e208f1b63"
 }
 cudl_viewer_health_check_status_code        = "200"
 cudl_viewer_allowed_methods                 = ["HEAD", "GET", "OPTIONS"]


### PR DESCRIPTION
- Adjust version of base_architecture module to v2.2.0
- Adjust version of workload modules to v3.4.0
- Change `ec2_instance_type` to `t3.small`
- Add `appendToThumbnail` and `appendToImage` arguments to `cudl-global.properties` file
- Update `caching.enabled` value to true in` cudl-global.properties.ttfpl`
- Increase value of `solr_ecs_task_def_memory` local variable
- Add `services_url` argument to `templates/viewer/cudl-global.properties.ttfpl`
- Update value of image sha in cudl_viewer_ecr_repositories variable