### PR TITLE
feat(data-processing): Update EFS to allow alternative throughput modes

### DIFF
--- a/cul-cudl-staging/main.tf
+++ b/cul-cudl-staging/main.tf
@@ -1,5 +1,5 @@
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.0.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.3.0"
 
   name_prefix                    = local.base_name_prefix
   ec2_instance_type              = var.ec2_instance_type
@@ -27,6 +27,8 @@ module "cudl-data-processing" {
   dst-s3-prefix                             = var.dst-s3-prefix
   efs-name                                  = var.efs-name
   efs_subnets                               = zipmap(["${local.base_name_prefix}-subnet-private-a", "${local.base_name_prefix}-subnet-private-b"], module.base_architecture.vpc_private_subnet_ids)
+  efs_file_system_throughput_mode           = var.data_processing_efs_throughput_mode
+  efs_file_system_provisioned_throughput    = var.data_processing_efs_provisioned_throughput
   lambda-alias-name                         = var.lambda-alias-name
   releases-root-directory-path              = var.releases-root-directory-path
   tmp-dir                                   = var.tmp-dir
@@ -53,7 +55,7 @@ module "cudl-data-processing" {
 }
 
 module "content_loader" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.2"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.5.0"
 
   name_prefix                               = join("-", compact([local.environment, var.content_loader_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id
@@ -108,7 +110,7 @@ module "content_loader" {
 }
 
 module "solr" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.2"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.5.0"
 
   name_prefix                                    = join("-", compact([local.environment, var.solr_name_suffix]))
   account_id                                     = data.aws_caller_identity.current.account_id
@@ -158,7 +160,7 @@ module "solr" {
 }
 
 module "cudl_services" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.2"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.5.0"
 
   name_prefix                               = join("-", compact([local.environment, var.cudl_services_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id
@@ -196,7 +198,7 @@ module "cudl_services" {
 }
 
 module "cudl_viewer" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.3.2"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.5.0"
 
   name_prefix                               = join("-", compact([local.environment, var.cudl_viewer_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id

--- a/cul-cudl-staging/templates/viewer/cudl-global.properties.ttfpl
+++ b/cul-cudl-staging/templates/viewer/cudl-global.properties.ttfpl
@@ -15,6 +15,10 @@ cudl-viewer-content.images.path=${mount_path}/data/pages/images
 enable.refresh=true
 caching.enabled=false
 
+# Value to append to image server URL
+appendToThumbnail=.jp2/full/,180/0/default.jpg
+appendToImage=.jp2
+
 GoogleAnalyticsId=${google_analytics_id}
 GA4GoogleAnalyticsId=${ga4_google_analytics_id}
 

--- a/cul-cudl-staging/terraform.tf
+++ b/cul-cudl-staging/terraform.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.44.0"
+      version = "~> 5.70.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.1.0"
+      version = "~> 2.5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -347,7 +347,7 @@ cudl_services_domain_name       = "services"
 cudl_services_target_group_port = 8085
 cudl_services_container_port    = 3000
 cudl_services_ecr_repositories = {
-  "cudl/services" = "sha256:98b7ee01cca8c1093d3d719d13640db9f9d7e2439933d847a63e733d96f4660e"
+  "cudl/services" = "sha256:40bbe5f4238ab768b2ccdf7e860791d8d821aa5a2d8744f93ea59ed972efbbbc"
 }
 cudl_services_health_check_status_code = "404"
 cudl_services_allowed_methods          = ["HEAD", "GET", "OPTIONS"]

--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -281,9 +281,12 @@ dst-s3-prefix     = ""
 tmp-dir           = "/tmp/dest/"
 lambda-alias-name = "LIVE"
 
-releases-root-directory-path = "/data"
-efs-name                     = "cudl-data-releases-efs"
-cloudfront_route53_zone_id   = "Z03809063VDGJ8MKPHFRV"
+releases-root-directory-path               = "/data"
+efs-name                                   = "cudl-data-releases-efs"
+cloudfront_route53_zone_id                 = "Z03809063VDGJ8MKPHFRV"
+data_processing_efs_throughput_mode        = "provisioned"
+data_processing_efs_provisioned_throughput = 3
+
 
 # Base Architecture
 cluster_name_suffix            = "cudl-ecs"
@@ -354,7 +357,7 @@ cudl_viewer_domain_name       = "viewer"
 cudl_viewer_target_group_port = 5008
 cudl_viewer_container_port    = 8080
 cudl_viewer_ecr_repositories = {
-  "cudl/viewer" = "sha256:e8ab599cc3233d59085b8c1652662204dac6aed21209443e8cf7741f71fde6d6"
+  "cudl/viewer" = "sha256:8af91b68471dcd20ebed2a116f26c91c0796529194982fab784f1ebfa1944369"
 }
 cudl_viewer_health_check_status_code        = "200"
 cudl_viewer_allowed_methods                 = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"] # NOTE need to allow email feedback

--- a/cul-cudl-staging/variables.tf
+++ b/cul-cudl-staging/variables.tf
@@ -127,6 +127,16 @@ variable "transform-lambda-bucket-sqs-notifications" {
   type        = list(any)
 }
 
+variable "data_processing_efs_throughput_mode" {
+  type        = string
+  description = "Throughput mode for the file system. Valid values: bursting, provisioned, or elastic"
+}
+
+variable "data_processing_efs_provisioned_throughput" {
+  type        = number
+  description = "The throughput, measured in MiB/s, that you want to provision for the file system"
+}
+
 variable "create_cloudfront_distribution" {
   description = "Whether to create a CloudFront distribution for access to the dest-bucket"
   type        = string

--- a/modules/cudl-data-processing/efs.tf
+++ b/modules/cudl-data-processing/efs.tf
@@ -1,5 +1,7 @@
 resource "aws_efs_file_system" "efs-volume" {
-  encrypted = true
+  encrypted                       = true
+  throughput_mode                 = var.efs_file_system_throughput_mode
+  provisioned_throughput_in_mibps = var.efs_file_system_provisioned_throughput
 
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -257,6 +257,18 @@ variable "efs_subnets" {
   default     = {}
 }
 
+variable "efs_file_system_throughput_mode" {
+  type        = string
+  description = "Throughput mode for the file system. Valid values: bursting, provisioned, or elastic"
+  default     = "bursting"
+}
+
+variable "efs_file_system_provisioned_throughput" {
+  type        = number
+  description = "The throughput, measured in MiB/s, that you want to provision for the file system"
+  default     = null
+}
+
 variable "datasync_task_s3_to_efs_pattern" {
   type        = string
   description = "Pattern regex used in S3 to EFS task"


### PR DESCRIPTION
- Add `throughput_mode` and `provisioned_throughput_in_mibps` to `aws_efs_file_system.efs-volume` in `modules/cudl-data-processing`
- Add `efs_file_system_throughput_mode` and `efs_file_system_provisioned_throughput` input variables to `modules/cudl-data-processing/variables.tf`
- Update module versions in `cul-cudl-staging`
- Update `cudl-viewer` image version in `cul-cudl-staging`
- Add `data_processing_efs_throughput_mode` and `data_processing_efs_provisioned_throughput` variables in `cul-cudl-staging`
- Update provider versions in `cul-cudl-staging`