### PR TITLE
Add CloudFront access logging and bot control to WAF

### DIFF
--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -1,22 +1,25 @@
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.3.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.4.0"
 
-  name_prefix                    = local.base_name_prefix
-  ec2_instance_type              = var.ec2_instance_type
-  ec2_additional_userdata        = var.ec2_additional_userdata
-  route53_zone_domain_name       = var.registered_domain_name
-  route53_zone_id_existing       = var.route53_zone_id_existing
-  route53_zone_force_destroy     = var.route53_zone_force_destroy
-  asg_desired_capacity           = var.asg_desired_capacity
-  asg_max_size                   = var.asg_max_size
-  alb_enable_deletion_protection = var.alb_enable_deletion_protection
-  vpc_public_subnet_public_ip    = var.vpc_public_subnet_public_ip
-  cloudwatch_log_group           = var.cloudwatch_log_group # TODO create log group
-  vpc_cidr_block                 = var.vpc_cidr_block
-  acm_create_certificate         = false
-  acm_certificate_arn            = var.acm_certificate_arn
-  waf_use_rate_limiting          = true
-  tags                           = local.default_tags
+  name_prefix                             = local.base_name_prefix
+  ec2_instance_type                       = var.ec2_instance_type
+  ec2_additional_userdata                 = var.ec2_additional_userdata
+  route53_zone_domain_name                = var.registered_domain_name
+  route53_zone_id_existing                = var.route53_zone_id_existing
+  route53_zone_force_destroy              = var.route53_zone_force_destroy
+  asg_desired_capacity                    = var.asg_desired_capacity
+  asg_max_size                            = var.asg_max_size
+  alb_enable_deletion_protection          = var.alb_enable_deletion_protection
+  vpc_public_subnet_public_ip             = var.vpc_public_subnet_public_ip
+  cloudwatch_log_group                    = var.cloudwatch_log_group # TODO create log group
+  vpc_cidr_block                          = var.vpc_cidr_block
+  acm_create_certificate                  = false
+  acm_certificate_arn                     = var.acm_certificate_arn
+  waf_use_rate_limiting                   = true
+  waf_use_bot_control                     = true
+  waf_bot_control_enable_machine_learning = true
+  waf_bot_control_inspection_level        = var.waf_bot_control_inspection_level
+  tags                                    = local.default_tags
 }
 
 module "cudl-data-processing" {
@@ -55,7 +58,7 @@ module "cudl-data-processing" {
 }
 
 module "solr" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.5.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.6.0"
 
   name_prefix                                    = join("-", compact([local.environment, var.solr_name_suffix]))
   account_id                                     = data.aws_caller_identity.current.account_id
@@ -105,7 +108,7 @@ module "solr" {
 }
 
 module "cudl_services" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.5.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.6.0"
 
   name_prefix                               = join("-", compact([local.environment, var.cudl_services_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id
@@ -144,7 +147,7 @@ module "cudl_services" {
 }
 
 module "cudl_viewer" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.5.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-workload-ecs.git?ref=v3.6.0"
 
   name_prefix                               = join("-", compact([local.environment, var.cudl_viewer_name_suffix]))
   account_id                                = data.aws_caller_identity.current.account_id
@@ -199,6 +202,8 @@ module "cudl_viewer" {
   cloudwatch_log_group_arn                = module.base_architecture.cloudwatch_log_group_arn
   cloudfront_waf_acl_arn                  = module.base_architecture.waf_acl_arn
   cloudfront_allowed_methods              = var.cudl_viewer_allowed_methods
+  cloudfront_access_logging               = true
+  cloudfront_access_logging_bucket        = aws_s3_bucket.cloudfront_access_logging.bucket_domain_name
   cloudfront_viewer_response_function_arn = aws_cloudfront_function.viewer-cors-header.arn
   # cloudfront_viewer_request_function_arn = aws_cloudfront_function.viewer.arn
   efs_use_existing_filesystem   = true

--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -1,5 +1,5 @@
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.4.0"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.5.1"
 
   name_prefix                             = local.base_name_prefix
   ec2_instance_type                       = var.ec2_instance_type
@@ -19,6 +19,8 @@ module "base_architecture" {
   waf_use_bot_control                     = true
   waf_bot_control_enable_machine_learning = true
   waf_bot_control_inspection_level        = var.waf_bot_control_inspection_level
+  waf_bot_control_exclusion_header        = var.waf_bot_control_exclusion_header
+  waf_bot_control_exclusion_header_value  = var.waf_bot_control_exclusion_header_value
   tags                                    = local.default_tags
 }
 

--- a/cul-cudl-production/s3.tf
+++ b/cul-cudl-production/s3.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "cloudfront_access_logging" {
+  bucket = join("-", [local.base_name_prefix, "cloudfront-access-logs"])
+}
+
+# ACLs need to be enabled by changing the ownership controls to allow access logging
+resource "aws_s3_bucket_ownership_controls" "cloudfront_access_logging" {
+  bucket = aws_s3_bucket.cloudfront_access_logging.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}

--- a/cul-cudl-production/terraform.tfvars
+++ b/cul-cudl-production/terraform.tfvars
@@ -138,24 +138,25 @@ efs-name                     = "cudl-data-releases-efs"
 cloudfront_route53_zone_id   = "Z03809063VDGJ8MKPHFRV"
 
 # Base Architecture
-cluster_name_suffix            = "cudl-ecs"
-registered_domain_name         = "cudl.lib.cam.ac.uk."
-asg_desired_capacity           = 3 # n = number of tasks
-asg_max_size                   = 4 # n + 1
-asg_allow_all_egress           = true
-ec2_instance_type              = "t3.large"
-ec2_additional_userdata        = <<-EOF
+cluster_name_suffix              = "cudl-ecs"
+registered_domain_name           = "cudl.lib.cam.ac.uk."
+asg_desired_capacity             = 3 # n = number of tasks
+asg_max_size                     = 4 # n + 1
+asg_allow_all_egress             = true
+ec2_instance_type                = "t3.large"
+ec2_additional_userdata          = <<-EOF
 echo 1 > /proc/sys/vm/swappiness
 echo ECS_RESERVED_MEMORY=256 >> /etc/ecs/ecs.config
 EOF
-route53_zone_id_existing       = "Z03809063VDGJ8MKPHFRV"
-route53_zone_force_destroy     = true
-acm_certificate_arn            = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
-acm_certificate_arn_us-east-1  = "arn:aws:acm:us-east-1:438117829123:certificate/3ebbcb94-1cf1-4adf-832f-add73eaea151"
-alb_enable_deletion_protection = false
-vpc_cidr_block                 = "10.27.0.0/22" #1024 adresses
-vpc_public_subnet_public_ip    = false
-cloudwatch_log_group           = "/ecs/CUDL"
+route53_zone_id_existing         = "Z03809063VDGJ8MKPHFRV"
+route53_zone_force_destroy       = true
+acm_certificate_arn              = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
+acm_certificate_arn_us-east-1    = "arn:aws:acm:us-east-1:438117829123:certificate/3ebbcb94-1cf1-4adf-832f-add73eaea151"
+alb_enable_deletion_protection   = false
+vpc_cidr_block                   = "10.27.0.0/22" #1024 adresses
+vpc_public_subnet_public_ip      = false
+cloudwatch_log_group             = "/ecs/CUDL"
+waf_bot_control_inspection_level = "TARGETED"
 
 # SOLR Worload
 solr_name_suffix       = "solr"

--- a/cul-cudl-production/terraform.tfvars
+++ b/cul-cudl-production/terraform.tfvars
@@ -138,25 +138,27 @@ efs-name                     = "cudl-data-releases-efs"
 cloudfront_route53_zone_id   = "Z03809063VDGJ8MKPHFRV"
 
 # Base Architecture
-cluster_name_suffix              = "cudl-ecs"
-registered_domain_name           = "cudl.lib.cam.ac.uk."
-asg_desired_capacity             = 3 # n = number of tasks
-asg_max_size                     = 4 # n + 1
-asg_allow_all_egress             = true
-ec2_instance_type                = "t3.large"
-ec2_additional_userdata          = <<-EOF
+cluster_name_suffix                    = "cudl-ecs"
+registered_domain_name                 = "cudl.lib.cam.ac.uk."
+asg_desired_capacity                   = 3 # n = number of tasks
+asg_max_size                           = 4 # n + 1
+asg_allow_all_egress                   = true
+ec2_instance_type                      = "t3.large"
+ec2_additional_userdata                = <<-EOF
 echo 1 > /proc/sys/vm/swappiness
 echo ECS_RESERVED_MEMORY=256 >> /etc/ecs/ecs.config
 EOF
-route53_zone_id_existing         = "Z03809063VDGJ8MKPHFRV"
-route53_zone_force_destroy       = true
-acm_certificate_arn              = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
-acm_certificate_arn_us-east-1    = "arn:aws:acm:us-east-1:438117829123:certificate/3ebbcb94-1cf1-4adf-832f-add73eaea151"
-alb_enable_deletion_protection   = false
-vpc_cidr_block                   = "10.27.0.0/22" #1024 adresses
-vpc_public_subnet_public_ip      = false
-cloudwatch_log_group             = "/ecs/CUDL"
-waf_bot_control_inspection_level = "TARGETED"
+route53_zone_id_existing               = "Z03809063VDGJ8MKPHFRV"
+route53_zone_force_destroy             = true
+acm_certificate_arn                    = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
+acm_certificate_arn_us-east-1          = "arn:aws:acm:us-east-1:438117829123:certificate/3ebbcb94-1cf1-4adf-832f-add73eaea151"
+alb_enable_deletion_protection         = false
+vpc_cidr_block                         = "10.27.0.0/22" #1024 adresses
+vpc_public_subnet_public_ip            = false
+cloudwatch_log_group                   = "/ecs/CUDL"
+waf_bot_control_inspection_level       = "TARGETED"
+waf_bot_control_exclusion_header       = "user-agent"
+waf_bot_control_exclusion_header_value = "StatusCake"
 
 # SOLR Worload
 solr_name_suffix       = "solr"

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -220,6 +220,11 @@ variable "cloudwatch_log_group" {
   description = "Name of the cloudwatch log group"
 }
 
+variable "waf_bot_control_inspection_level" {
+  type        = string
+  description = "The inspection level to use for the Base Architecture WAF Bot Control rule group"
+}
+
 variable "solr_name_suffix" {
   type        = string
   description = "Suffix to add to SOLR resource names"

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -225,6 +225,16 @@ variable "waf_bot_control_inspection_level" {
   description = "The inspection level to use for the Base Architecture WAF Bot Control rule group"
 }
 
+variable "waf_bot_control_exclusion_header" {
+  type        = string
+  description = "Name of header to exclude from WAF bot control"
+}
+
+variable "waf_bot_control_exclusion_header_value" {
+  type        = string
+  description = "Value of header to exclude from WAF bot control"
+}
+
 variable "solr_name_suffix" {
   type        = string
   description = "Suffix to add to SOLR resource names"


### PR DESCRIPTION
- Upgrade `base_architecture` module version to  v2.5.1, workload modules to v3.6.0
- Add `cul-cudl-production/s3.tf` with `aws_s3_bucket.cloudfront_access_logging` resource
- Add `cloudfront_access_logging` and `cloudfront_access_logging_bucket` arguments to `cudl_viewer` module
- Add `waf_use_bot_control`, `waf_bot_control_enable_machine_learning` and `waf_bot_control_inspection_level` arguments to `base_architecture` module
- Add `waf_bot_control_exclusion_header` and `waf_bot_control_exclusion_header_value` arguments to `base_architecture` module to exclude requests containing `user-agent` headers matching `StatusCake`
- Add `waf_bot_control_exclusion_header` and `waf_bot_control_exclusion_header_value` variables