### PR TITLE
Updating to set URI exclusions to bot control in WAF

### DIFF
--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -1,5 +1,5 @@
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.5.2"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v3.0.0"
 
   name_prefix                             = local.base_name_prefix
   ec2_instance_type                       = var.ec2_instance_type

--- a/cul-cudl-production/main.tf
+++ b/cul-cudl-production/main.tf
@@ -1,5 +1,5 @@
 module "base_architecture" {
-  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.5.1"
+  source = "git::https://github.com/cambridge-collection/terraform-aws-architecture-ecs.git?ref=v2.5.2"
 
   name_prefix                             = local.base_name_prefix
   ec2_instance_type                       = var.ec2_instance_type
@@ -19,8 +19,7 @@ module "base_architecture" {
   waf_use_bot_control                     = true
   waf_bot_control_enable_machine_learning = true
   waf_bot_control_inspection_level        = var.waf_bot_control_inspection_level
-  waf_bot_control_exclusion_header        = var.waf_bot_control_exclusion_header
-  waf_bot_control_exclusion_header_value  = var.waf_bot_control_exclusion_header_value
+  waf_bot_control_exclusions              = var.waf_bot_control_exclusions
   tags                                    = local.default_tags
 }
 

--- a/cul-cudl-production/templates/viewer/cudl-global.properties.ttfpl
+++ b/cul-cudl-production/templates/viewer/cudl-global.properties.ttfpl
@@ -51,7 +51,7 @@ smtp_port=${smtp_port}
 
 #robots.txt (varies between live, dev etc).
 robots.useragent=User-agent: *
-robots.disallow=Disallow:
+robots.disallow=Disallow: /search
 
 # UI Javascript/CSS configuration
 

--- a/cul-cudl-production/terraform.tfvars
+++ b/cul-cudl-production/terraform.tfvars
@@ -138,28 +138,37 @@ efs-name                     = "cudl-data-releases-efs"
 cloudfront_route53_zone_id   = "Z03809063VDGJ8MKPHFRV"
 
 # Base Architecture
-cluster_name_suffix                    = "cudl-ecs"
-registered_domain_name                 = "cudl.lib.cam.ac.uk."
-asg_desired_capacity                   = 3 # n = number of tasks
-asg_max_size                           = 4 # n + 1
-asg_allow_all_egress                   = true
-ec2_instance_type                      = "t3.large"
-ec2_additional_userdata                = <<-EOF
+cluster_name_suffix              = "cudl-ecs"
+registered_domain_name           = "cudl.lib.cam.ac.uk."
+asg_desired_capacity             = 3 # n = number of tasks
+asg_max_size                     = 4 # n + 1
+asg_allow_all_egress             = true
+ec2_instance_type                = "t3.large"
+ec2_additional_userdata          = <<-EOF
 echo 1 > /proc/sys/vm/swappiness
 echo ECS_RESERVED_MEMORY=256 >> /etc/ecs/ecs.config
 EOF
-route53_zone_id_existing               = "Z03809063VDGJ8MKPHFRV"
-route53_zone_force_destroy             = true
-acm_certificate_arn                    = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
-acm_certificate_arn_us-east-1          = "arn:aws:acm:us-east-1:438117829123:certificate/3ebbcb94-1cf1-4adf-832f-add73eaea151"
-alb_enable_deletion_protection         = false
-vpc_cidr_block                         = "10.27.0.0/22" #1024 adresses
-vpc_public_subnet_public_ip            = false
-cloudwatch_log_group                   = "/ecs/CUDL"
-waf_bot_control_inspection_level       = "TARGETED"
-waf_bot_control_exclusion_header       = "user-agent"
-waf_bot_control_exclusion_header_value = "StatusCake"
-
+route53_zone_id_existing         = "Z03809063VDGJ8MKPHFRV"
+route53_zone_force_destroy       = true
+acm_certificate_arn              = "arn:aws:acm:eu-west-1:438117829123:certificate/fec4f8c7-8c2d-4274-abc4-a6fa3f65583f"
+acm_certificate_arn_us-east-1    = "arn:aws:acm:us-east-1:438117829123:certificate/3ebbcb94-1cf1-4adf-832f-add73eaea151"
+alb_enable_deletion_protection   = false
+vpc_cidr_block                   = "10.27.0.0/22" #1024 adresses
+vpc_public_subnet_public_ip      = false
+cloudwatch_log_group             = "/ecs/CUDL"
+waf_bot_control_inspection_level = "TARGETED"
+waf_bot_control_exclusions = [
+  {
+    "waf_bot_control_exclusion_header"       = "user-agent",
+    "waf_bot_control_exclusion_header_value" = "StatusCake"
+  },
+  {
+    "waf_bot_control_exclusion_uri" = "/iiif/"
+  },
+  {
+    "waf_bot_control_exclusion_uri" = "/v1/"
+  }
+]
 # SOLR Worload
 solr_name_suffix       = "solr"
 solr_domain_name       = "search"

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -225,14 +225,15 @@ variable "waf_bot_control_inspection_level" {
   description = "The inspection level to use for the Base Architecture WAF Bot Control rule group"
 }
 
-variable "waf_bot_control_exclusion_header" {
-  type        = string
-  description = "Name of header to exclude from WAF bot control"
-}
-
-variable "waf_bot_control_exclusion_header_value" {
-  type        = string
-  description = "Value of header to exclude from WAF bot control"
+variable "waf_bot_control_exclusions" {
+  description = "A list of objects containing information about the WAF exclusions"
+  type = list(object({
+    waf_bot_control_exclusion_header         = optional(string)             // Name of header to exclude from WAF bot control
+    waf_bot_control_exclusion_header_value   = optional(string)             // Value of header to exclude from WAF bot control
+    waf_bot_control_exclusion_match_type     = optional(string, "CONTAINS") // Match type for the bot control exclusion header
+    waf_bot_control_exclusion_text_transform = optional(string, "NONE")     // Text transformation to apply before matching the exclusion header for WAF bot control
+    waf_bot_control_exclusion_uri            = optional(string)             // URI pattern to exclude from waf
+  }))
 }
 
 variable "solr_name_suffix" {


### PR DESCRIPTION
This requires the new version of the ECS module for exclusions for bot control.

It adds in exclusions for the URIs /iiif/ and /v1/ for the bot control in the WAF.