### PR TITLE
Add CloudWatch subscription filter in production environment

### DIFF
--- a/cul-cudl-production/cloudwatch.tf
+++ b/cul-cudl-production/cloudwatch.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudwatch_log_subscription_filter" "logging_destination" {
+  name            = format("%s-logging-destination", local.base_name_prefix)
+  log_group_name  = module.base_architecture.cloudwatch_log_group_name
+  filter_pattern  = ""
+  destination_arn = var.cloudwatch_log_destination_arn
+  distribution    = "ByLogStream"
+}

--- a/cul-cudl-production/terraform.tfvars
+++ b/cul-cudl-production/terraform.tfvars
@@ -156,6 +156,7 @@ alb_enable_deletion_protection   = false
 vpc_cidr_block                   = "10.27.0.0/22" #1024 adresses
 vpc_public_subnet_public_ip      = false
 cloudwatch_log_group             = "/ecs/CUDL"
+cloudwatch_log_destination_arn   = "arn:aws:logs:eu-west-1:874581676011:destination:cul-logs-cloudwatch-log-destination"
 waf_bot_control_inspection_level = "TARGETED"
 waf_bot_control_rule_action_overrides = [
   "TGT_SignalAutomatedBrowser",

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -220,6 +220,11 @@ variable "cloudwatch_log_group" {
   description = "Name of the cloudwatch log group"
 }
 
+variable "cloudwatch_log_destination_arn" {
+  type        = string
+  description = "ARN of a CloudWatch Log Destination"
+}
+
 variable "waf_bot_control_inspection_level" {
   type        = string
   description = "The inspection level to use for the Base Architecture WAF Bot Control rule group"


### PR DESCRIPTION
The log destination is in the `cul-logs` account

- Add `aws_cloudwatch_log_subscription_filter.logging_destination` resource in `cul-cudl-production/cloudwatch.tf`
- Add variable `cloudwatch_log_destination_arn` in `cul-cudl-production/variables.tf` and `terraform.tfvars`