### PR TITLE
Feature/add ephemeral storage config

### DIFF
--- a/cudl-sandbox/variables.tf
+++ b/cudl-sandbox/variables.tf
@@ -85,7 +85,7 @@ variable "transform-lambda-information" {
     use_additional_variables       = optional(bool, false)
     use_enhancements_variables     = optional(bool, false)
     mount_fs                       = optional(bool, false)
-    ephemeral_storage              = optional (number, 512)
+    ephemeral_storage              = optional(number, 512)
   }))
 }
 

--- a/cudl-sandbox/variables.tf
+++ b/cudl-sandbox/variables.tf
@@ -85,6 +85,7 @@ variable "transform-lambda-information" {
     use_additional_variables       = optional(bool, false)
     use_enhancements_variables     = optional(bool, false)
     mount_fs                       = optional(bool, false)
+    ephemeral_storage              = optional (number, 512)
   }))
 }
 

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -79,7 +79,7 @@ variable "transform-lambda-information" {
     use_additional_variables   = optional(bool, false)
     use_enhancements_variables = optional(bool, false)
     mount_fs                   = optional(bool, false)
-    ephemeral_storage              = optional (number, 512)
+    ephemeral_storage          = optional(number, 512)
   }))
 }
 

--- a/cul-cudl-production/variables.tf
+++ b/cul-cudl-production/variables.tf
@@ -79,6 +79,7 @@ variable "transform-lambda-information" {
     use_additional_variables   = optional(bool, false)
     use_enhancements_variables = optional(bool, false)
     mount_fs                   = optional(bool, false)
+    ephemeral_storage              = optional (number, 512)
   }))
 }
 

--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -189,6 +189,7 @@ transform-lambda-information = [
     "maximum_concurrency"      = 100
     "use_datadog_variables"    = false
     "use_additional_variables" = true
+    "ephemeral_storage"        = 1024
     "environment_variables" = {
       ANT_TARGET             = "full"
       SEARCH_HOST            = "solr-api-cudl-ecs.staging-solr"

--- a/cul-cudl-staging/variables.tf
+++ b/cul-cudl-staging/variables.tf
@@ -80,6 +80,7 @@ variable "transform-lambda-information" {
     use_additional_variables       = optional(bool, false)
     use_enhancements_variables     = optional(bool, false)
     mount_fs                       = optional(bool, false)
+    ephemeral_storage              = optional (number, 512)
   }))
 }
 

--- a/cul-cudl-staging/variables.tf
+++ b/cul-cudl-staging/variables.tf
@@ -80,7 +80,7 @@ variable "transform-lambda-information" {
     use_additional_variables       = optional(bool, false)
     use_enhancements_variables     = optional(bool, false)
     mount_fs                       = optional(bool, false)
-    ephemeral_storage              = optional (number, 512)
+    ephemeral_storage              = optional(number, 512)
   }))
 }
 

--- a/modules/cudl-data-processing/lambda.tf
+++ b/modules/cudl-data-processing/lambda.tf
@@ -15,6 +15,10 @@ resource "aws_lambda_function" "create-transform-lambda-function" {
   handler       = var.transform-lambda-information[count.index].handler
   publish       = true
 
+  ephemeral_storage {
+    size = var.transform-lambda-information[count.index].ephemeral_storage
+  }
+
   dynamic "image_config" {
     for_each = (var.transform-lambda-information[count.index].command != null ||
       var.transform-lambda-information[count.index].entry_point != null ||

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -66,6 +66,7 @@ variable "transform-lambda-information" {
     use_additional_variables       = optional(bool, false)
     use_enhancements_variables     = optional(bool, false)
     mount_fs                       = optional(bool, false)
+    ephemeral_storage              = optional(number, 512)
   }))
 }
 


### PR DESCRIPTION
Adding ephemeral storage configuration to lambda to allow some lambdas that require extra storage to be able to have this. 

Currently required by TEI processing in staging. 