### PR TITLE
fix(staging): add ENABLE_TEI_SHA_IN_CORE_XML env to tei processing

### DIFF
--- a/cul-cudl-staging/terraform.tfvars
+++ b/cul-cudl-staging/terraform.tfvars
@@ -205,6 +205,7 @@ transform-lambda-information = [
       LAMBDA_TIMEOUT_MARGIN_MS       = 180000
       ENABLE_SHA_METADATA            = "true"
       ENABLE_RELEASE_STATUS_METADATA = "true"
+      ENABLE_TEI_SHA_IN_CORE_XML     = "true"
       LOG_LEVEL                      = "ERROR"
 
     }


### PR DESCRIPTION
Forgot to add this env into staging, so the viewer and dp json currently don't have the tei item's SHA in them.