### PR TITLE
feat(cudl-data-processing): configurable CloudFront cache policies and ordered behaviors

### DIFF
--- a/modules/cudl-data-processing/cloudfront.tf
+++ b/modules/cudl-data-processing/cloudfront.tf
@@ -66,13 +66,14 @@ resource "aws_cloudfront_distribution" "this" {
   dynamic "ordered_cache_behavior" {
     for_each = local.occb
     content {
-      path_pattern           = ordered_cache_behavior.value.path_pattern
-      allowed_methods        = ordered_cache_behavior.value.allowed_methods
-      cached_methods         = ordered_cache_behavior.value.cached_methods
-      compress               = ordered_cache_behavior.value.compress
-      target_origin_id       = local.cloudfront_distribution_domain_name
-      viewer_protocol_policy = "redirect-to-https"
-      cache_policy_id        = data.aws_cloudfront_cache_policy.selected[ordered_cache_behavior.value.cache_policy_name].id
+      path_pattern               = ordered_cache_behavior.value.path_pattern
+      allowed_methods            = ordered_cache_behavior.value.allowed_methods
+      cached_methods             = ordered_cache_behavior.value.cached_methods
+      compress                   = ordered_cache_behavior.value.compress
+      target_origin_id           = local.cloudfront_distribution_domain_name
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.selected[ordered_cache_behavior.value.cache_policy_name].id
+      response_headers_policy_id = ordered_cache_behavior.value.response_headers_policy_id
 
       dynamic "function_association" {
         for_each = ordered_cache_behavior.value.attach_viewer_request_function && var.cloudfront_viewer_request_function_arn != null ? [1] : []

--- a/modules/cudl-data-processing/cloudfront.tf
+++ b/modules/cudl-data-processing/cloudfront.tf
@@ -1,6 +1,15 @@
-data "aws_cloudfront_cache_policy" "managed_caching_disabled" {
+locals {
+  occb = var.cloudfront_ordered_cache_behaviors
+  cache_policy_names = toset(concat(
+    [var.cloudfront_default_cache_policy],
+    [for b in local.occb : b.cache_policy_name],
+  ))
+}
+
+data "aws_cloudfront_cache_policy" "selected" {
+  for_each = local.cache_policy_names
   provider = aws.us-east-1
-  name     = "Managed-CachingDisabled"
+  name     = each.value
 }
 
 resource "aws_cloudfront_origin_access_control" "this" {
@@ -43,13 +52,34 @@ resource "aws_cloudfront_distribution" "this" {
     smooth_streaming       = false
     target_origin_id       = local.cloudfront_distribution_domain_name
     viewer_protocol_policy = "redirect-to-https"
-    cache_policy_id        = data.aws_cloudfront_cache_policy.managed_caching_disabled.id
+    cache_policy_id        = data.aws_cloudfront_cache_policy.selected[var.cloudfront_default_cache_policy].id
 
     dynamic "function_association" {
       for_each = var.cloudfront_viewer_request_function_arn != null ? [1] : []
       content {
         event_type   = "viewer-request"
         function_arn = var.cloudfront_viewer_request_function_arn
+      }
+    }
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = local.occb
+    content {
+      path_pattern           = ordered_cache_behavior.value.path_pattern
+      allowed_methods        = ordered_cache_behavior.value.allowed_methods
+      cached_methods         = ordered_cache_behavior.value.cached_methods
+      compress               = ordered_cache_behavior.value.compress
+      target_origin_id       = local.cloudfront_distribution_domain_name
+      viewer_protocol_policy = "redirect-to-https"
+      cache_policy_id        = data.aws_cloudfront_cache_policy.selected[ordered_cache_behavior.value.cache_policy_name].id
+
+      dynamic "function_association" {
+        for_each = ordered_cache_behavior.value.attach_viewer_request_function && var.cloudfront_viewer_request_function_arn != null ? [1] : []
+        content {
+          event_type   = "viewer-request"
+          function_arn = var.cloudfront_viewer_request_function_arn
+        }
       }
     }
   }

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -259,6 +259,35 @@ variable "cloudfront_access_logging_bucket" {
   default     = null
 }
 
+variable "cloudfront_default_cache_policy" {
+  description = "Managed cache-policy name for the CloudFront distribution's default cache behavior"
+  type        = string
+  default     = "Managed-CachingDisabled"
+}
+
+variable "cloudfront_ordered_cache_behaviors" {
+  description = <<-EOT
+    Ordered path-specific cache behaviors, evaluated BEFORE the default (first match wins).
+    Empty = unchanged. path_pattern matches the INCOMING viewer URI, before the viewer-request
+    function rewrites it (match "/letters-timeline-json" or "/view/*", not "/sites/.../letters.json"
+    or "*.html"). List specific patterns before broad ones.
+  EOT
+  type = list(object({
+    path_pattern                   = string
+    cache_policy_name              = optional(string, "Managed-CachingOptimized")
+    compress                       = optional(bool, true)
+    allowed_methods                = optional(list(string), ["GET", "HEAD", "OPTIONS"])
+    cached_methods                 = optional(list(string), ["GET", "HEAD"])
+    attach_viewer_request_function = optional(bool, true)
+  }))
+  default = []
+
+  validation {
+    condition     = length(distinct([for b in var.cloudfront_ordered_cache_behaviors : b.path_pattern])) == length(var.cloudfront_ordered_cache_behaviors)
+    error_message = "path_pattern values must be unique (CloudFront rejects duplicate ordered behaviors)."
+  }
+}
+
 variable "efs_nfs_mount_port" {
   type        = number
   description = "NFS protocol port for EFS mounts"

--- a/modules/cudl-data-processing/variables.tf
+++ b/modules/cudl-data-processing/variables.tf
@@ -271,6 +271,8 @@ variable "cloudfront_ordered_cache_behaviors" {
     Empty = unchanged. path_pattern matches the INCOMING viewer URI, before the viewer-request
     function rewrites it (match "/letters-timeline-json" or "/view/*", not "/sites/.../letters.json"
     or "*.html"). List specific patterns before broad ones.
+    response_headers_policy_id takes an ID, not a name, so the caller can pass a resource
+    reference: no AWS managed policy sets Cache-Control, so downstream no-store needs a custom one.
   EOT
   type = list(object({
     path_pattern                   = string
@@ -279,6 +281,7 @@ variable "cloudfront_ordered_cache_behaviors" {
     allowed_methods                = optional(list(string), ["GET", "HEAD", "OPTIONS"])
     cached_methods                 = optional(list(string), ["GET", "HEAD"])
     attach_viewer_request_function = optional(bool, true)
+    response_headers_policy_id     = optional(string)
   }))
   default = []
 


### PR DESCRIPTION
Adds two variables to `modules/cudl-data-processing` so deployments can cache the whole site and enable compression at the edge while keeping specific paths uncached, such as `/search`.

| Variable | Type | Default |
| --- | --- | --- |
| `cloudfront_default_cache_policy` | `string` (cache policy **name**) | `"Managed-CachingDisabled"` |
| `cloudfront_ordered_cache_behaviors` | `list(object({...}))` | `[]` |

**IMPORTANT: the defaults preserve the existing CloudFront configuration (`Managed-CachingDisabled`), so existing callers should see no managed-resource changes. Terraform may still refresh the renamed cache-policy data source.**

Reference implementation: `darwin-editorial` commit `9cfc36f` in `darwin-terraform`.

## Recipe: cache the site, exclude the search path

For search to be uncached, it needs a response headers policy (to prevent client-side caching) and a cache policy (to prevent caching at edge). Without an explicit cache directive, a browser or other downstream cache may reuse the response.

### 1. Custom response headers policy for `no-store`

```hcl
# cloudfront.tf (caller)
resource "aws_cloudfront_response_headers_policy" "no_store" {
  name    = "${local.environment}-no-store"
  comment = "Prevent browser and proxy caching of live query responses"

  custom_headers_config {
    items {
      header   = "Cache-Control"
      value    = "no-store"
      override = true
    }
  }
}
```

### 2. Ordered behavior pinning the search path to "never cache"

```hcl
# locals.tf (caller)
locals {
  # Matches the incoming viewer URI, before the viewer-request function rewrites it.
  cloudfront_ordered_cache_behaviors = [
    {
      path_pattern               = "/search*" # live query endpoint; must stay dynamic
      cache_policy_name          = "Managed-CachingDisabled"
      response_headers_policy_id = aws_cloudfront_response_headers_policy.no_store.id
    },
  ]
}
```

**IMPORTANT: define this list in a `locals` block in a `.tf` file, not `terraform.tfvars`, because `response_headers_policy_id` takes an ID and a `.tfvars` file cannot reference a resource.** I'd suggest putting a pointer comment beside the other CloudFront settings in `terraform.tfvars` so we don't forget the locals changes.

**IMPORTANT: `path_pattern` matches the INCOMING viewer URI, before an CF function rewrites.**

**IMPORTANT: `/search*` is a plain prefix glob and also captures any other path beginning with `/search`.** If that is too broad, use narrower patterns. Query strings are never part of `path_pattern` matching.

The list takes as many entries as you need — add one per path that must not be cached, reusing the same response headers policy:

```hcl
cloudfront_ordered_cache_behaviors = [
  {
    path_pattern               = "/search*"
    cache_policy_name          = "Managed-CachingDisabled"
    response_headers_policy_id = aws_cloudfront_response_headers_policy.no_store.id
  },
  {
    path_pattern               = "/api/*"
    cache_policy_name          = "Managed-CachingDisabled"
    response_headers_policy_id = aws_cloudfront_response_headers_policy.no_store.id
  },
]
```

Entries can mix policies freely — an ordered behavior is just an override, so some can cache and some cannot. Each one counts against the distribution's CloudFront cache-behavior quota, so prefer one glob over several literal paths where the patterns allow it.

### 3. Turn caching on for everything else and wire it up

```hcl
# terraform.tfvars
cloudfront_default_cache_policy = "Managed-CachingOptimized"
# cloudfront_ordered_cache_behaviors is in locals.tf; it references a response headers policy resource
```

```hcl
# main.tf (caller)
module "cudl-data-processing" {
  # ...
  cloudfront_default_cache_policy    = var.cloudfront_default_cache_policy
  cloudfront_ordered_cache_behaviors = local.cloudfront_ordered_cache_behaviors
}
```

**IMPORTANT: after publishing a full-site update, create a CloudFront invalidation for `/*` in the console for the changes to be visible immediately.** `Managed-CachingOptimized` can otherwise continue serving cached objects until their TTLs expire.

```sh
aws cloudfront create-invalidation --distribution-id DISTRIBUTION_ID --paths "/*"
```

### 4. Compression

Nothing extra to set: the module already hardcodes `compress = true` on the default behavior, and
`compress` defaults to `true` for each ordered behavior. Compression is switched on by the cache
policy choice in step 3.

**IMPORTANT: CloudFront only compresses when the behavior has `compress = true` AND the cache policy
enables gzip/brotli in the cache key.** `Managed-CachingDisabled` has both disabled, so the site has
been serving uncompressed responses despite `compress = true`. `Managed-CachingOptimized` enables
both, so step 3 turns compression on as a side effect.

To leave a path uncached but still compressed, a managed policy will not do it — create a custom
cache policy with all three TTLs set to `0` and gzip/brotli enabled, then reference it by name:

```hcl
resource "aws_cloudfront_cache_policy" "no_cache_compressed" {
  provider    = aws.us-east-1
  name        = "${local.environment}-no-cache-compressed"
  min_ttl     = 0
  default_ttl = 0
  max_ttl     = 0

  parameters_in_cache_key_and_forwarded_to_origin {
    enable_accept_encoding_gzip   = true
    enable_accept_encoding_brotli = true
    cookies_config { cookie_behavior = "none" }
    headers_config { header_behavior = "none" }
    query_strings_config { query_string_behavior = "all" }
  }
}
```

`cache_policy_name` resolves custom policies as well as managed ones, so
`cache_policy_name = aws_cloudfront_cache_policy.no_cache_compressed.name` works in the behaviors
list.

### 5. Verify

```
terraform plan   # expect an in-place update to aws_cloudfront_distribution.this[0], no replacement
```

After apply:

```sh
# Search is deliberately uncached: both requests should report Miss and no-store.
for attempt in 1 2; do
  curl -sSI 'https://<host>/search?q=test' | grep -iE '^(x-cache|cache-control):'
done

# / is the site root (index.html) and uses the default cache behavior.
# Repeated requests should report Hit once the cache is warm.
for attempt in 1 2; do
  curl -sSI 'https://<host>/' | grep -iE '^(x-cache|cache-control):'
done

# Compression: expect content-encoding: gzip (or br for -H 'Accept-Encoding: br').
curl -sSI -H 'Accept-Encoding: gzip' 'https://<host>/' | grep -i '^content-encoding:'
```

## Per-behavior object fields

```hcl
path_pattern                   = string                  # required
cache_policy_name              = optional(string, "Managed-CachingOptimized")
compress                       = optional(bool, true)
allowed_methods                = optional(list(string), ["GET", "HEAD", "OPTIONS"])
cached_methods                 = optional(list(string), ["GET", "HEAD"])
attach_viewer_request_function = optional(bool, true)
response_headers_policy_id     = optional(string)
```

## Remaining gotchas

**IMPORTANT: ordered behaviors are evaluated before the default, in list order, first match wins.** Put specific patterns above broad ones — a leading `/*` swallows everything after it.

**IMPORTANT: ordered behaviors do not inherit the default behavior's function association.** The module attaches `cloudfront_viewer_request_function_arn` to each one because `attach_viewer_request_function` defaults to `true`. Setting it `false` sends the unrewritten URI to S3, which 403/404s on any path relying on the rewrite — including search.

**IMPORTANT: `cache_policy_name` is resolved by name via a data source on the us-east-1 provider.** A typo or a policy absent from the account fails at plan time, not apply.

`path_pattern` values must be unique — there is a validation block for this, since CloudFront rejects duplicate ordered behaviors with an unhelpful error.

Callers pinning `?ref=` to a branch (e.g. `ref=caching`) must be moved to the release tag once this merges.
